### PR TITLE
Firefox 지원?

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,8 @@
     }
   ],
   "background": {
-    "service_worker": "scripts/service/serviceWorker.js"
+    "service_worker": "scripts/service/serviceWorker.js",
+    "scripts": ["scripts/service/serviceWorker.js"]
   },
   "host_permissions": ["https://solved.ac/api/v3/*"],
   "permissions": ["storage"]

--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -232,7 +232,7 @@ async function getWebhookMessage(
   attemps
 ) {
   const solved = await getProblemData(problemId);
-  console.log(solved);
+  //console.log(solved);
 
   const getTagName = (tag) => {
     const key = tag.key;

--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -232,7 +232,7 @@ async function getWebhookMessage(
   attemps
 ) {
   const solved = await getProblemData(problemId);
-  // console.log(solved);
+  console.log(solved);
 
   const getTagName = (tag) => {
     const key = tag.key;

--- a/scripts/page/popup.js
+++ b/scripts/page/popup.js
@@ -12,9 +12,7 @@ function injectSettingPage() {
   const setting = document.getElementById("a-setting-page");
   if (!setting) return;
 
-  const id = chrome.runtime.id;
-
-  setting.href = `chrome-extension://${id}/popup/settings.html`;
+  setting.href = browser.runtime.getURL('popup/settings.html')
 }
 
 /**


### PR DESCRIPTION
일단 간단한 수정만으로 Firefox에 호환 가능한 것을 확인했습니다. 
Firefox에서 작동시키기 위해서는 manifest.json에
```json
  "browser_specific_settings": {
    "gecko": {
      "id": "bjcord@example.com"
    }
  }
```
등을 통해 아이디를 추가하고, signing 과정을 거치면 되는 것으로 알고 있습니다.

(참고)
https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/
https://support.mozilla.org/en-US/kb/add-on-signing-in-firefox