### PR TITLE
BJCORD 1.5.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "백준코드",
   "description": "Automatically send BOJ to your discord server",
   "homepage_url": "https://github.com/BaekjoonCord/BJCORD-extension",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "karpitony, YEAHx4",
   "action": {
     "default_icon": "assets/thumbnail.png",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "백준코드",
   "description": "Automatically send BOJ to your discord server",
   "homepage_url": "https://github.com/BaekjoonCord/BJCORD-extension",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": "karpitony, YEAHx4",
   "action": {
     "default_icon": "assets/thumbnail.png",

--- a/scripts/content/boj.js
+++ b/scripts/content/boj.js
@@ -40,7 +40,11 @@ function watch() {
       const { username, resultCategory } = data;
 
       if (username == getHandle()) {
-        if (resultCategory == "judging") {
+        if (
+          resultCategory === "judging" ||
+          resultCategory === "wait" ||
+          resultCategory === "compile"
+        ) {
           if (!isJudging) {
             isJudging = true;
             judgeStartTime = new Date().getTime();

--- a/scripts/content/boj.js
+++ b/scripts/content/boj.js
@@ -17,10 +17,8 @@ if (!!handle) {
 
 /**
  * 내 제출 페이지에서 채점 중인 제출이 있는지 확인한다.
- * 기존엔 120초 내 AC가 있었다면 웹훅을 전송했지만
- * 채점이 오래 걸리면 제대로 감지하지 못하는 경우가 있었다.
  * 10초 내 AC는 바로 웹훅을 전송하고 10초 이상된 AC는
- * isJudging이 true인지 확인하고 전송한다.
+ * `isJudging`이 true인지 확인하고 전송한다.
  */
 let isJudging = false;
 let judgeStartTime = 0;
@@ -42,12 +40,6 @@ function watch() {
       const { username, resultCategory } = data;
 
       if (username == getHandle()) {
-        // if (
-        //   resultCategory == "judging" ||
-        //   resultCategory == "compile" ||
-        //   resultCategory == "wait"
-        // )
-        //   return;
         if (resultCategory == "judging") {
           if (!isJudging) {
             isJudging = true;

--- a/scripts/content/boj.js
+++ b/scripts/content/boj.js
@@ -116,18 +116,22 @@ function watch() {
           /**  메시지 전송 결과에 따라 체크 또는 X 표시
            * 모든 웹훅이 정상 작동되면 체크 표시
            * 웹훅이 아무것도 등록이 안된 경우에는 X로 표시
-          */
-          const statusCell = document.querySelector('span.result-text.result-ac');
-          
+           */
+          const statusCell = document.querySelector(
+            "span.result-text.result-ac"
+          );
+
           if (statusCell) {
             if (success > 0 && failed === 0) {
               statusCell.innerHTML += " ✔️";
             } else {
-              statusCell.innerHTML += " ❌";
+              if (failed !== 0) statusCell.innerHTML += " ❌";
             }
+          } else {
+            logErr("Status cell not found. Cannot append status.");
           }
         })();
       }
     }
-  }, 1000);
+  }, 100);
 }

--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -62,7 +62,9 @@ function unescapeHtml(text) {
   );
 }
 
-/** 문자열을 unescape 하여 반환합니다. */
+/**
+ * 문자열을 unescape 하여 반환합니다.
+ */
 String.prototype.unescapeHtml = function () {
   return unescapeHtml(this);
 };

--- a/scripts/page/settings.js
+++ b/scripts/page/settings.js
@@ -38,9 +38,9 @@ function render() {
   if (webhooks.length) {
     webhooksElement.innerHTML = "";
     webhooksElement.append(...wh);
-  }
-  else {
-    webhooksElement.innerHTML = "<span style='font-size: large;'>등록된 웹훅이 없습니다.</span>";
+  } else {
+    webhooksElement.innerHTML =
+      "<span style='font-size: large;'>등록된 웹훅이 없습니다.</span>";
   }
 }
 
@@ -102,6 +102,7 @@ async function load() {
   console.log("Webhooks loaded");
   console.log(data);
 }
+
 /**
  * 이벤트 리스너를 추가하고 초기 렌더링을 수행합니다.
  */


### PR DESCRIPTION
- 웹훅 전송 완료/실패 시 "채점 결과" 칸에 이모지를 추가합니다.
  - 활성화된 웹훅이 하나도 없을 경우 추가되지 않습니다.
- 채점 결과를 더 빠르게 감지합니다.
- "대기 중", "컴파일 중" 상태에서 로그가 도배되던 문제를 해결했습니다.