### PR TITLE
알고리즘 분류가 없을 경우 분류 텍스트를 숨기도록 개선

### DIFF
--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -251,9 +251,11 @@ async function getWebhookMessage(
       {
         title: `[${bj_level[solved.level]}] ${problemId}번: ${solved.titleKo}`,
         url: `https://www.acmicpc.net/problem/${problemId}`,
-        description: `[코드 보기](https://www.acmicpc.net/source/${submissionId})\n태그: ||${solved.tags
-          .map(getTagName)
-          .join(", ")}||`,
+        description: `[코드 보기](https://www.acmicpc.net/source/${submissionId})\n${
+          solved.tags.length > 0
+            ? `태그: ||${solved.tags.map(getTagName).join(", ")}||`
+            : ""
+        }`,
         color: getColor(bj_level[solved.level].split(" ")[0].toLowerCase()),
         fields: [
           {


### PR DESCRIPTION
## 📝 PR 설명
본 PR에서는 맞춘 문제에서 알고리즘 분류가 없을 경우 분류 텍스트를 자연스럽게 숨기도록 개선하였습니다. Discord 스포일러 메시지는 `||` 를 양끝에 붙이는 것으로 설정할 수 있는데, 아무 알고리즘 분류도 없다보니 스포일러에 사용되는 `||` 가 그대로 보여서, 개선해 보고 싶었습니다.

<img src="https://github.com/user-attachments/assets/966e276c-6329-480c-a388-5310b511eab1" width="350px" />

## 📷 스크린샷
- 본 PR을 적용한다면 이제 알고리즘 분류가 없는 문제에서는 아래와 같이 웹훅 메시지가 보일 것입니다.

<img src="https://github.com/user-attachments/assets/3549689d-d54e-4bb7-b4a0-ea2c3ff12896" width="350px" />

- 또한 아래와 같이 적용하지는 않았지만, 해당 문제에는 알고리즘 분류가 없다는 점을 명시적으로 표현하시기를 원하시는 경우 이 안도 나쁘지 않아 보입니다.

<img src="https://github.com/user-attachments/assets/04d13e87-e1cb-4402-a9f1-c2c5c0ef6ae5" width="350px" />
