### PR TITLE
BOJ 언어가 영어인 경우 결과를 불러오지 못하던 문제 해결 (BJCORD 1.7.1)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "백준코드",
   "description": "Automatically send BOJ to your discord server",
   "homepage_url": "https://github.com/BaekjoonCord/BJCORD-extension",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "karpitony, YEAHx4",
   "action": {
     "default_icon": "assets/thumbnail.png",

--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -23,7 +23,7 @@ function getHandle() {
  * @param {*} text 로그에 출력할 값
  */
 function log(text) {
-  console.log("[BJCORD-dev]", text);
+  console.log("[BJCORD]", text);
 }
 
 /**
@@ -82,30 +82,39 @@ function getResultTable() {
   }
 
   const mapTableHeader = (header) => {
-    switch (header) {
+    switch (header.toLowerCase()) {
       case "문제번호":
       case "문제":
+      case "problem":
         return "problemId";
       case "난이도":
         return "level";
       case "결과":
+      case "result":
         return "result";
       case "문제내용":
         return "problemDescription";
       case "언어":
+      case "language":
         return "language";
       case "제출 번호":
+      case "solution":
         return "submissionId";
       case "아이디":
+      case "user":
         return "username";
       case "제출시간":
       case "제출한 시간":
+      case "submission time":
         return "submissionTime";
       case "시간":
+      case "time":
         return "runtime";
       case "메모리":
+      case "memory":
         return "memory";
       case "코드 길이":
+      case "length":
         return "codeLength";
       default:
         return "unknown";

--- a/scripts/page/popup.js
+++ b/scripts/page/popup.js
@@ -13,7 +13,6 @@ function injectSettingPage() {
   if (!setting) return;
 
   const id = chrome.runtime.id;
-
   setting.href = `chrome-extension://${id}/popup/settings.html`;
 }
 


### PR DESCRIPTION
- BOJ의 언어가 영어로 설정되어 있는 경우 채점 결과를 불러오지 못하고 웹훅도 전송하지 않던 문제를 해결했습니다.