### PR TITLE
언어/코드 길이가 비공개여서 정보가 없는 경우 "?" 로 표시되도록 개선

### DIFF
--- a/scripts/content/lib.js
+++ b/scripts/content/lib.js
@@ -274,7 +274,7 @@ async function getWebhookMessage(
           },
           {
             name: "언어",
-            value: `${language}`,
+            value: language || "?",
             inline: true,
           },
           {
@@ -289,7 +289,7 @@ async function getWebhookMessage(
           },
           {
             name: "코드 길이",
-            value: `${length} B`,
+            value: length ? `${length} B` : "?",
             inline: true,
           },
           {


### PR DESCRIPTION
## 🗨️ 관련 이슈
> close #49

## 📝 PR 설명
본 PR에서는 **언어 / 코드 길이 정보가 비공개여서 정보가 없는 경우 "?" 로 표시되도록** 예외 처리 코드를 추가했습니다. 이러한 상황에 대해서는 이슈를 참고하여 주시기 바랍니다.
- #49 

작업 사항은 이미지로 요약이 가능할 것 같습니다.

<img width="600" height="362" alt="image" src="https://github.com/user-attachments/assets/c62a5300-16e8-4c0a-9223-d8c1ab07712c" />
