### PR TITLE
[HOTFIX] BJCORD 2.0.1

### DIFF
--- a/components/popup/webhook-list.tsx
+++ b/components/popup/webhook-list.tsx
@@ -28,7 +28,7 @@ export default function WebhookList() {
     <div
       className={cn(
         "bg-[#424549] w-full p-4 rounded-sm h-48",
-        "overflow-auto flex flex-col"
+        "overflow-auto flex flex-col gap-2"
       )}
     >
       {webhooks.length ? (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bjcord",
   "description": "디스코드에 방금 푼 문제를 전송해 보세요!",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -20,15 +20,8 @@ export default defineConfig({
     },
     permissions: ["storage"],
     host_permissions: [
-      "*://www.acmicpc.net/*",
-      "*://acmicpc.net/*",
+      "https://www.acmicpc.net/*",
       "https://solved.ac/api/v3/*",
-    ],
-    web_accessible_resources: [
-      {
-        matches: ["*://www.acmicpc.net/*", "*://acmicpc.net/*"],
-        resources: ["/main-world-script.js"],
-      },
     ],
   }),
   vite: () => ({


### PR DESCRIPTION
기존 BJCORD는 `www.acmicpc.net` 에 대해서만 권한을 가지고 있었습니다.
BJCORD 2.0에서 `acmicpc.net`에 대한 권한이 추가되어 업데이트 후 비활성화되는 문제가 발생했습니다.
다시 원래 확장과 동일한 권한으로 축소합니다.