### PR TITLE
[HOTFIX] BJCORD 2.0.2

### DIFF
--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -120,6 +120,26 @@ export const getWebhooks = async (): Promise<Webhook[]> => {
     await syncWebhooks(webhooks);
   }
 
+  // BJCORD 1 버전에선 active필드가 enabled로 저장되어 있었습니다.
+  // enabled 필드가 존재하는 경우 active 필드로 복사하고 enabled 필드를 제거합니다.
+  let hasEnabledField = false;
+  for (const wh of webhooks) {
+    if ((wh as any).enabled !== undefined) {
+      hasEnabledField = true;
+      break;
+    }
+  }
+
+  if (hasEnabledField) {
+    for (const wh of webhooks) {
+      if ((wh as any).enabled !== undefined) {
+        wh.active = (wh as any).enabled;
+        delete (wh as any).enabled;
+      }
+    }
+    await syncWebhooks(webhooks);
+  }
+
   return webhooks;
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bjcord",
   "description": "디스코드에 방금 푼 문제를 전송해 보세요!",
   "private": true,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
BJCORD 1에서는 웹훅 활성화 필드가 enabled 였습니다.
BJCORD 2로 옮기면서 active로 변경했는데, migration 코드가 작성되지 않아 모든 웹훅이 비활성화 되는
문제가 생겼습니다. 이 PR은 enabled 필드가 있는 경우 active 필드로 복사하고 enabled를 삭제합니다.

문제가 생겼던 2.0.0은 임시로 1.7.2 버전으로 롤백해 두었습니다. 롤백된 버전이 2.0.1로 배포되어 2.0.2로 올립니다.