### PR TITLE
평균 시도의 소숫점이 길게 출력되는 문제

### DIFF
--- a/lib/boj.ts
+++ b/lib/boj.ts
@@ -414,7 +414,7 @@ export async function getWebhookMessage(
           },
           {
             name: "평균 시도",
-            value: `${solved.averageTries} 회`,
+            value: `${Math.round(solved.averageTries * 1000) / 1000} 회`,
             inline: true,
           },
           {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bjcord",
   "description": "디스코드에 방금 푼 문제를 전송해 보세요!",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
최근 solved.ac API 변화로 평균 시도가 길게 출력되는 문제가 있습니다.
반올림헤 최대 3자리까지만 표시되도록 수정했습니다.

<img width="574" height="616" alt="image" src="https://github.com/user-attachments/assets/d8be9b09-890f-44bf-b5aa-88bca094f474" />
