### PR TITLE
웹훅 별 전송할 문제 난이도(티어) 설정 기능 추가

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "@/styles/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/shadcn-utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/components/options/option-add-btn.tsx
+++ b/components/options/option-add-btn.tsx
@@ -4,7 +4,7 @@ export default function OptionAddBtn({ onClick }: { onClick: () => void }) {
   return (
     <button
       className={cn(
-        "w-[5%] bg-[#3556ca] h-full rounded-sm",
+        "w-full bg-[#3556ca] h-full rounded-sm",
         "cursor-pointer hover:bg-[#2e4bb8]",
         "text-white font-bold transition-colors"
       )}

--- a/components/options/option-header.tsx
+++ b/components/options/option-header.tsx
@@ -8,10 +8,11 @@ export default function OptionHeader() {
         "p-2 rounded-sm"
       )}
     >
-      <div className="w-[20%] text-center font-bold">웹훅 이름</div>
-      <div className="w-[50%] text-center font-bold">웹훅 URL</div>
-      <div className="w-[20%] text-center font-bold">표시될 이름</div>
-      <div className="w-[10%] text-center font-bold" />
+      <div className="w-[18%] text-center font-bold">웹훅 이름</div>
+      <div className="w-[38%] text-center font-bold">웹훅 URL</div>
+      <div className="w-[16%] text-center font-bold">표시될 이름</div>
+      <div className="w-[22%] text-center font-bold">티어 범위</div>
+      <div className="w-[6%] text-center font-bold" />
     </div>
   );
 }

--- a/components/options/option-header.tsx
+++ b/components/options/option-header.tsx
@@ -11,7 +11,7 @@ export default function OptionHeader() {
       <div className="w-[18%] text-center font-bold">웹훅 이름</div>
       <div className="w-[38%] text-center font-bold">웹훅 URL</div>
       <div className="w-[16%] text-center font-bold">표시될 이름</div>
-      <div className="w-[22%] text-center font-bold">티어 범위</div>
+      <div className="w-[22%] text-center font-bold">난이도 범위</div>
       <div className="w-[6%] text-center font-bold" />
     </div>
   );

--- a/components/options/option-header.tsx
+++ b/components/options/option-header.tsx
@@ -4,15 +4,15 @@ export default function OptionHeader() {
   return (
     <div
       className={cn(
-        "bg-[#1e1f22] flex justify-between items-center w-full",
+        "bg-[#1e1f22] grid grid-cols-[22%_41%_20%_12%_5%] items-center w-full",
         "p-2 rounded-sm"
       )}
     >
-      <div className="w-[18%] text-center font-bold">웹훅 이름</div>
-      <div className="w-[38%] text-center font-bold">웹훅 URL</div>
-      <div className="w-[16%] text-center font-bold">표시될 이름</div>
-      <div className="w-[22%] text-center font-bold">난이도 범위</div>
-      <div className="w-[6%] text-center font-bold" />
+      <div className="w-full text-center font-bold">웹훅 이름</div>
+      <div className="w-full text-center font-bold">웹훅 URL</div>
+      <div className="w-full text-center font-bold">표시될 이름</div>
+      <div className="w-full text-center font-bold">난이도 범위</div>
+      <div className="w-full text-center font-bold" />
     </div>
   );
 }

--- a/components/options/option-input-field.tsx
+++ b/components/options/option-input-field.tsx
@@ -2,6 +2,7 @@ import cn from "@yeahx4/cn";
 import OptionInput from "./option-input";
 import OptionAddBtn from "./option-add-btn";
 import OptionCheckbox from "./option-checkbox";
+import TierRangeTooltip from "@/components/options/tier-range-tooltip";
 import { Webhook } from "@/lib/webhook";
 import {
   getSendFirstAcOnly,
@@ -17,6 +18,12 @@ export default function OptionInputField({
   setDisplayNameInput,
   setNameInput,
   setUrlInput,
+  tierMinInput,
+  setTierMinInput,
+  tierMaxInput,
+  setTierMaxInput,
+  includeUnratedInput,
+  setIncludeUnratedInput,
   handleAddWebhook,
 }: {
   nameInput: string;
@@ -25,15 +32,25 @@ export default function OptionInputField({
   setUrlInput: (url: string) => void;
   displayNameInput: string;
   setDisplayNameInput: (displayName: string) => void;
+  tierMinInput: number;
+  setTierMinInput: (value: number) => void;
+  tierMaxInput: number;
+  setTierMaxInput: (value: number) => void;
+  includeUnratedInput: boolean;
+  setIncludeUnratedInput: (value: boolean) => void;
   handleAddWebhook: () => void;
-  handleDeleteWebhook: (id: string) => void;
-  handleUpdateWebhook: (
-    id: string,
-    newWebhook: Partial<Omit<Webhook, "id">>
-  ) => void;
 }) {
   const [showEmoji, setShowEmoji] = useState(true);
   const [onlyFirstSolve, setOnlyFirstSolve] = useState(false);
+  const draftWebhook: Webhook = {
+    id: "draft",
+    name: "draft",
+    url: "draft",
+    active: true,
+    tierMin: tierMinInput,
+    tierMax: tierMaxInput,
+    includeUnrated: includeUnratedInput,
+  };
 
   useEffect(() => {
     (async () => {
@@ -56,31 +73,42 @@ export default function OptionInputField({
     <div className="flex flex-col gap-4">
       <div
         className={cn(
-          "flex justify-between items-center w-full gap-1",
+          "grid grid-cols-[21%_40%_20%_12%_5%] items-center w-full gap-1",
           "h-[36px]"
         )}
       >
         <OptionInput
-          className="w-[20%]"
+          className="w-full"
           placeholder="웹훅 이름"
           value={nameInput}
           onChange={setNameInput}
           handleAddWebhook={handleAddWebhook}
         />
         <OptionInput
-          className="w-[50%]"
+          className="w-full"
           placeholder="웹훅 URL (신뢰할 수 없는 타인에게 공유하지 마세요)"
           value={urlInput}
           onChange={setUrlInput}
           handleAddWebhook={handleAddWebhook}
         />
         <OptionInput
-          className="w-[25%]"
+          className="w-full"
           placeholder="표시될 이름"
           value={displayNameInput}
           onChange={setDisplayNameInput}
           handleAddWebhook={handleAddWebhook}
         />
+        <div className="bg-[#2c2f33] rounded-sm h-full flex items-center justify-center">
+          <TierRangeTooltip
+            webhook={draftWebhook}
+            handleUpdateWebhook={(_, updates) => {
+              if (updates.tierMin !== undefined) setTierMinInput(updates.tierMin);
+              if (updates.tierMax !== undefined) setTierMaxInput(updates.tierMax);
+              if (updates.includeUnrated !== undefined)
+                setIncludeUnratedInput(updates.includeUnrated);
+            }}
+          />
+        </div>
         <OptionAddBtn onClick={handleAddWebhook} />
       </div>
       <div className="flex flex-col gap-1">

--- a/components/options/option-webhook-item.tsx
+++ b/components/options/option-webhook-item.tsx
@@ -1,3 +1,4 @@
+import TierRangeTooltip from "@/components/options/tier-range-tooltip";
 import { Webhook } from "@/lib/webhook";
 import cn from "@yeahx4/cn";
 
@@ -56,8 +57,9 @@ export default function OptionWebhookItem({
         "h-8 bg-[#2c2f33] pl-4 pr-2 rounded-sm min-w-0"
       )}
     >
+      {/* 웹훅 이름 */}
       <div
-        className={cn("w-[20%] hover:cursor-text h-full flex items-center p-1")}
+        className={cn("w-[18%] hover:cursor-text h-full flex items-center p-1")}
       >
         {isEditingName ? (
           <input
@@ -82,8 +84,9 @@ export default function OptionWebhookItem({
         )}
       </div>
 
+      {/* 웹훅 URL */}
       <div
-        className={cn("w-[50%] hover:cursor-text h-full flex items-center p-1")}
+        className={cn("w-[38%] hover:cursor-text h-full flex items-center p-1")}
       >
         {isEditingUrl ? (
           <input
@@ -108,8 +111,9 @@ export default function OptionWebhookItem({
         )}
       </div>
 
+      {/* 표시될 이름 */}
       <div
-        className={cn("w-[25%] hover:cursor-text h-full flex items-center p-1")}
+        className={cn("w-[16%] hover:cursor-text h-full flex items-center p-1")}
       >
         {isEditingDisplayName ? (
           <input
@@ -137,9 +141,18 @@ export default function OptionWebhookItem({
         )}
       </div>
 
+      {/* 티어 범위 - 오버레이 팝오버 트리거 */}
+      <div className="w-[22%] h-full flex items-center px-1">
+        <TierRangeTooltip
+          webhook={webhook}
+          handleUpdateWebhook={handleUpdateWebhook}
+        />
+      </div>
+
+      {/* 삭제 버튼 */}
       <div
         className={cn(
-          "bg-red-500 text-white w-[5%] transition-all",
+          "bg-red-500 text-white w-[6%] transition-all",
           "cursor-pointer text-center rounded-sm hover:bg-red-600"
         )}
         onClick={() => handleDeleteWebhook(webhook.id)}

--- a/components/options/option-webhook-item.tsx
+++ b/components/options/option-webhook-item.tsx
@@ -53,14 +53,12 @@ export default function OptionWebhookItem({
   return (
     <div
       className={cn(
-        "flex justify-between items-center w-full",
+        "grid grid-cols-[22%_41%_20%_12%_5%] items-center w-full",
         "h-8 bg-[#2c2f33] pl-4 pr-2 rounded-sm min-w-0"
       )}
     >
       {/* 웹훅 이름 */}
-      <div
-        className={cn("w-[18%] hover:cursor-text h-full flex items-center p-1")}
-      >
+      <div className={cn("hover:cursor-text h-full flex items-center p-1 min-w-0")}>
         {isEditingName ? (
           <input
             className="w-full bg-[#2c2f33] outline-none"
@@ -85,9 +83,7 @@ export default function OptionWebhookItem({
       </div>
 
       {/* 웹훅 URL */}
-      <div
-        className={cn("w-[38%] hover:cursor-text h-full flex items-center p-1")}
-      >
+      <div className={cn("hover:cursor-text h-full flex items-center p-1 min-w-0")}>
         {isEditingUrl ? (
           <input
             className="w-full bg-[#2c2f33] outline-none"
@@ -112,9 +108,7 @@ export default function OptionWebhookItem({
       </div>
 
       {/* 표시될 이름 */}
-      <div
-        className={cn("w-[16%] hover:cursor-text h-full flex items-center p-1")}
-      >
+      <div className={cn("hover:cursor-text h-full flex items-center p-1 min-w-0")}>
         {isEditingDisplayName ? (
           <input
             className="w-full bg-[#2c2f33] outline-none"
@@ -142,7 +136,7 @@ export default function OptionWebhookItem({
       </div>
 
       {/* 티어 범위 - 오버레이 팝오버 트리거 */}
-      <div className="w-[22%] h-full flex items-center px-1">
+      <div className="h-full flex items-center px-1 min-w-0">
         <TierRangeTooltip
           webhook={webhook}
           handleUpdateWebhook={handleUpdateWebhook}
@@ -152,12 +146,13 @@ export default function OptionWebhookItem({
       {/* 삭제 버튼 */}
       <div
         className={cn(
-          "bg-red-500 text-white w-[6%] transition-all",
-          "cursor-pointer text-center rounded-sm hover:bg-red-600"
+          "bg-red-500 text-white w-full h-5 transition-all",
+          "cursor-pointer rounded-sm hover:bg-red-600",
+          "flex justify-center items-center"
         )}
         onClick={() => handleDeleteWebhook(webhook.id)}
       >
-        X
+        <p>X</p>
       </div>
     </div>
   );

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -24,8 +24,36 @@ import { useClickOutside } from "@/hooks/use-click-outside";
 const TIER_MIN = DEFAULT_TIER_SELECTION_START;
 const TIER_MAX = DEFAULT_TIER_SELECTION_END;
 const TIER_RANGE = TIER_MAX - TIER_MIN;
+const TIER_SHORT_PREFIX: Record<string, string> = {
+  Bronze: "B",
+  Silver: "S",
+  Gold: "G",
+  Platinum: "P",
+  Diamond: "D",
+  Ruby: "R",
+  Master: "M",
+};
 
-function TierChip({
+function getTierShortLabel(level: number) {
+  if (level === 0) return "Un";
+
+  const tierName = TIER_NAME[level];
+  if (!tierName) return String(level);
+  if (tierName === "Master") return "M";
+
+  const [tier, roman] = tierName.split(" ");
+  const romanToNum: Record<string, string> = {
+    I: "1",
+    II: "2",
+    III: "3",
+    IV: "4",
+    V: "5",
+  };
+
+  return `${TIER_SHORT_PREFIX[tier] ?? tier}${romanToNum[roman] ?? roman}`;
+}
+
+function TierIcon({
   level,
   className,
 }: {
@@ -50,6 +78,32 @@ function TierChip({
           (e.target as HTMLImageElement).style.display = "none";
         }}
       />
+    </div>
+  );
+}
+
+function TierChip({
+  level,
+  className,
+}: {
+  level: number;
+  className?: string;
+}) {
+  const color = getTierColor(level);
+
+  return (
+    <div
+      className={cn(
+        "flex h-6 items-center justify-center rounded-full border pl-1.5 pr-2",
+        className
+      )}
+      style={{ color, borderColor: color }}
+      title={TIER_NAME[level]}
+    >
+      <TierIcon level={level} />
+      <p className="text-sm font-bold leading-none">
+        {getTierShortLabel(level)}
+      </p>
     </div>
   );
 }
@@ -168,10 +222,10 @@ export default function TierRangeTooltip({
         )}
       >
         <span className="flex min-w-0 items-center gap-1.5">
-          {includeUnrated ? <TierChip level={0} className="h-5" /> : null}
-          <TierChip level={minVal} className="h-5" />
+          {includeUnrated ? <TierIcon level={0} className="h-5" /> : null}
+          <TierIcon level={minVal} className="h-5" />
           <span className="text-gray-500">~</span>
-          <TierChip level={maxVal} className="h-5" />
+          <TierIcon level={maxVal} className="h-5" />
         </span>
       </button>
 

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import {
-  DEFAULT_TIER_SELECTOR_END,
-  DEFAULT_TIER_SELECTOR_START,
+  DEFAULT_TIER_SELECTION_END,
+  DEFAULT_TIER_SELECTION_START,
   TIER_NAME,
 } from "@/lib/constants";
 import { Webhook } from "@/lib/webhook";
@@ -10,7 +10,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select";
 import cn from "@yeahx4/cn";
 import {
@@ -22,7 +21,40 @@ import {
 } from "@/lib/tier";
 import { useClickOutside } from "@/hooks/use-click-outside";
 
-/** 티어 이미지 + 이름을 함께 표시하는 셀렉트 아이템 row */
+const TIER_MIN = DEFAULT_TIER_SELECTION_START;
+const TIER_MAX = DEFAULT_TIER_SELECTION_END;
+const TIER_RANGE = TIER_MAX - TIER_MIN;
+
+function TierChip({
+  level,
+  className,
+}: {
+  level: number;
+  className?: string;
+}) {
+  const tierName = TIER_NAME[level] ?? "Unknown";
+
+  return (
+    <div
+      className={cn(
+        "inline-flex h-6 w-6 items-center justify-center rounded-full",
+        className
+      )}
+      title={tierName}
+    >
+      <img
+        src={`${BASE_IMG}${getTierImg(level)}.png`}
+        alt={tierName}
+        className="h-4 w-4 object-contain"
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.display = "none";
+        }}
+      />
+    </div>
+  );
+}
+
+/** 티어 이름을 함께 표시하는 셀렉트 아이템 row */
 function TierRow({ level }: { level: number }) {
   return (
     <span className="flex items-center gap-2">
@@ -52,26 +84,28 @@ export default function TierRangeTooltip({
   const [open, setOpen] = useState(false);
   const selectOpenRef = useRef(0);
   const [minVal, setMinVal] = useState(
-    webhook.tierMin ?? DEFAULT_TIER_SELECTOR_START
+    Math.max(webhook.tierMin ?? TIER_MIN, TIER_MIN)
   );
-  const [maxVal, setMaxVal] = useState(
-    webhook.tierMax ?? DEFAULT_TIER_SELECTOR_END
+  const [maxVal, setMaxVal] = useState(webhook.tierMax ?? TIER_MAX);
+  const [includeUnrated, setIncludeUnrated] = useState(
+    webhook.includeUnrated ?? webhook.tierMin === 0
   );
-  const [popupStyle, setPopupStyle] = useState<React.CSSProperties>({});
+  const [popupStyle, setPopupStyle] = useState<CSSProperties>({});
 
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setMinVal(webhook.tierMin ?? DEFAULT_TIER_SELECTOR_START);
-    setMaxVal(webhook.tierMax ?? DEFAULT_TIER_SELECTOR_END);
+    setMinVal(Math.max(webhook.tierMin ?? TIER_MIN, TIER_MIN));
+    setMaxVal(webhook.tierMax ?? TIER_MAX);
+    setIncludeUnrated(webhook.includeUnrated ?? webhook.tierMin === 0);
   }, [webhook.tierMin, webhook.tierMax]);
 
-  const calcPopupStyle = (): React.CSSProperties => {
+  const calcPopupStyle = (): CSSProperties => {
     if (!triggerRef.current) return {};
     const rect = triggerRef.current.getBoundingClientRect();
-    const popupWidth = 360;
-    const popupHeight = 340;
+    const popupWidth = 384;
+    const popupHeight = 420;
     const margin = 8;
     let left = rect.left;
     let top = rect.bottom + margin;
@@ -95,22 +129,22 @@ export default function TierRangeTooltip({
   );
 
   const commitMin = (val: number) => {
-    const v = Math.min(val, maxVal);
+    const v = Math.min(Math.max(val, TIER_MIN), maxVal);
     setMinVal(v);
     handleUpdateWebhook(webhook.id, { tierMin: v });
-
   };
   const commitMax = (val: number) => {
-    const v = Math.max(val, minVal);
+    const v = Math.max(Math.min(val, TIER_MAX), minVal);
     setMaxVal(v);
     handleUpdateWebhook(webhook.id, { tierMax: v });
-
   };
-  const handleMinDrag = (val: number) => setMinVal(Math.min(val, maxVal));
-  const handleMaxDrag = (val: number) => setMaxVal(Math.max(val, minVal));
+  const handleMinDrag = (val: number) =>
+    setMinVal(Math.min(Math.max(val, TIER_MIN), maxVal));
+  const handleMaxDrag = (val: number) =>
+    setMaxVal(Math.max(Math.min(val, TIER_MAX), minVal));
 
-  const minPct = (minVal / 30) * 100;
-  const maxPct = (maxVal / 30) * 100;
+  const minPct = ((minVal - TIER_MIN) / TIER_RANGE) * 100;
+  const maxPct = ((maxVal - TIER_MIN) / TIER_RANGE) * 100;
 
   const onSelectOpenChange = (o: boolean) => {
     if (o) selectOpenRef.current += 1;
@@ -123,22 +157,22 @@ export default function TierRangeTooltip({
       <button
         ref={triggerRef}
         onClick={handleOpen}
-        title={`${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`}
+        title={
+          includeUnrated
+            ? `Unrated, ${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`
+            : `${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`
+        }
         className={cn(
-          "text-[11px] px-2 py-0.5 rounded transition-colors w-full text-left truncate",
-          "bg-[#1e1f22] hover:bg-[#36393f]",
-          open ? "ring-1 ring-[#5865f2] text-white" : "text-gray-300"
+          "inline-flex w-full items-center justify-center rounded-md px-1 py-1",
+          "text-left text-[11px] transition-colors bg-[#1e1f22] hover:bg-[#2c2f33]",
         )}
       >
-        <>
-          <span style={{ color: getTierColor(minVal) }}>
-            {TIER_NAME[minVal]}
-          </span>
-          <span className="text-gray-500 mx-1">~</span>
-          <span style={{ color: getTierColor(maxVal) }}>
-            {TIER_NAME[maxVal]}
-          </span>
-        </>
+        <span className="flex min-w-0 items-center gap-1.5">
+          {includeUnrated ? <TierChip level={0} className="h-5" /> : null}
+          <TierChip level={minVal} className="h-5" />
+          <span className="text-gray-500">~</span>
+          <TierChip level={maxVal} className="h-5" />
+        </span>
       </button>
 
       {/* 오버레이 팝업 */}
@@ -149,13 +183,14 @@ export default function TierRangeTooltip({
           className={cn(
             "fixed z-[9999]",
             "bg-[#2c2f33] border border-[#5865f2]",
-            "rounded-xl shadow-2xl",
-            "p-6"
+            "rounded-xl shadow-2xl p-5"
           )}
         >
           {/* 헤더 */}
           <div className="flex items-center justify-between mb-4">
-            <span className="text-sm font-bold text-white">전송할 난이도 범위 설정</span>
+            <span className="text-sm font-bold text-white">
+              전송할 난이도 범위 설정
+            </span>
             <button
               onClick={() => setOpen(false)}
               className="text-gray-400 hover:text-white text-xs transition-colors leading-none"
@@ -165,14 +200,13 @@ export default function TierRangeTooltip({
           </div>
 
           {/* 현재 선택 표시 */}
-          <div className="flex justify-between text-xs mb-5 px-1">
-            <span className="font-semibold" style={{ color: getTierColor(minVal) }}>
-              {TIER_NAME[minVal]}
-            </span>
+          <div className="flex items-center justify-between text-xs mb-5 px-1">
+            <div className="flex items-center gap-1.5 min-w-0">
+              {includeUnrated ? <TierChip level={0} className="h-5" /> : null}
+              <TierChip level={minVal} className="h-5" />
+            </div>
             <span className="text-gray-500">~</span>
-            <span className="font-semibold" style={{ color: getTierColor(maxVal) }}>
-              {TIER_NAME[maxVal]}
-            </span>
+            <TierChip level={maxVal} className="h-5" />
           </div>
 
           {/* ── 슬라이더 영역 ── */}
@@ -184,29 +218,39 @@ export default function TierRangeTooltip({
                 style={{ left: `${minPct}%`, right: `${100 - maxPct}%` }}
               />
               <input
-                type="range" min={0} max={30} value={minVal}
+                type="range"
+                min={TIER_MIN}
+                max={TIER_MAX}
+                value={minVal}
                 onChange={(e) => handleMinDrag(Number(e.target.value))}
-                onMouseUp={(e) => commitMin(Number((e.target as HTMLInputElement).value))}
+                onMouseUp={(e) =>
+                  commitMin(Number((e.target as HTMLInputElement).value))
+                }
                 className="dual-range-input"
                 style={{ zIndex: minVal > 28 ? 5 : 3 }}
               />
               <input
-                type="range" min={0} max={30} value={maxVal}
+                type="range"
+                min={TIER_MIN}
+                max={TIER_MAX}
+                value={maxVal}
                 onChange={(e) => handleMaxDrag(Number(e.target.value))}
-                onMouseUp={(e) => commitMax(Number((e.target as HTMLInputElement).value))}
+                onMouseUp={(e) =>
+                  commitMax(Number((e.target as HTMLInputElement).value))
+                }
                 className="dual-range-input"
                 style={{ zIndex: 4 }}
               />
             </div>
 
-            {/* ── 티어 마커 (점 + 아이콘) ── */}
+            {/* ── 티어 마커 ── */}
             <div className="relative mt-1 px-[10px]" style={{ height: 44 }}>
               {TIER_MARKERS.map(({ level, img, label }) => {
                 const isActive = level >= minVal && level <= maxVal;
                 return (
                   <div
                     key={level}
-                    className="absolute flex flex-col items-center"
+                    className="absolute flex flex-col items-center gap-1"
                     style={{
                       left: thumbPos(level),
                       transform: "translateX(-50%)",
@@ -214,7 +258,7 @@ export default function TierRangeTooltip({
                     }}
                   >
                     <div
-                      className="w-1.5 h-1.5 rounded-full mb-0.75 transition-colors"
+                      className="w-1.5 h-1.5 rounded-full transition-colors"
                       style={{
                         backgroundColor: isActive
                           ? getTierColor(level)
@@ -238,9 +282,39 @@ export default function TierRangeTooltip({
               })}
             </div>
           </div>
+          
+          {/* Unrated 포함 체크 박스 */}
+          <div className="mt-4 rounded-lg border border-[#4f545c]/70 bg-[#1e1f22]/60 px-3 py-2">
+            <label className="flex cursor-pointer items-start gap-2 text-xs text-gray-200">
+              <input
+                type="checkbox"
+                checked={includeUnrated}
+                onChange={(e) => {
+                  const next = e.target.checked;
+                  setIncludeUnrated(next);
+                  handleUpdateWebhook(webhook.id, { includeUnrated: next });
+                }}
+                className="mt-0.5 h-4 w-4 accent-[#5865f2]"
+              />
+              <div>
+                <img 
+                  src={`${BASE_IMG}${getTierImg(0)}.png`} 
+                  alt="Unrated" 
+                  className="inline-block w-4 h-4 object-contain mr-1"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = "none";
+                  }}
+                />
+                <span className="font-semibold text-white">Unrated 포함</span>
+                <span className="block text-[11px] text-gray-400">
+                  체크 시 Unrated 문제도 전송됩니다.
+                </span>
+              </div>
+            </label>
+          </div>
 
           {/* 드롭다운 (Radix Select + 티어 이미지) */}
-          <div className="flex gap-3 items-end mt-4">
+          <div className="flex items-end gap-3 mt-4">
             {/* 하한 */}
             <div className="flex-1">
               <label className="block text-[10px] text-gray-400 mb-1.5 font-medium">
@@ -253,14 +327,19 @@ export default function TierRangeTooltip({
               >
                 <SelectTrigger
                   size="sm"
-                  className="w-full bg-[#1e1f22] border-[#4f545c] text-white text-xs h-8 focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                  className={cn(
+                    "w-full justify-start gap-1.5 bg-[#1e1f22] border-[#4f545c] ",
+                    "text-white text-xs h-8", 
+                    "focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                  )}
                 >
-                  <SelectValue>
-                    <TierRow level={minVal} />
-                  </SelectValue>
+                  <TierRow level={minVal} />
                 </SelectTrigger>
                 <SelectContent className="bg-[#1e1f22] border-[#4f545c] text-white max-h-56 z-[99999]">
-                  {Array.from({ length: 31 }, (_, i) => (
+                  {Array.from(
+                    { length: TIER_MAX - TIER_MIN + 1 },
+                    (_, i) => i + TIER_MIN
+                  ).map((i) => (
                     <SelectItem
                       key={i}
                       value={String(i)}
@@ -288,14 +367,18 @@ export default function TierRangeTooltip({
               >
                 <SelectTrigger
                   size="sm"
-                  className="w-full bg-[#1e1f22] border-[#4f545c] text-white text-xs h-8 focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                  className={cn(
+                    "w-full justify-start gap-1.5 bg-[#1e1f22] border-[#4f545c] text-white text-xs h-8",
+                    "focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                  )}
                 >
-                  <SelectValue>
-                    <TierRow level={maxVal} />
-                  </SelectValue>
+                  <TierRow level={maxVal} />
                 </SelectTrigger>
                 <SelectContent className="bg-[#1e1f22] border-[#4f545c] text-white max-h-56 z-[99999]">
-                  {Array.from({ length: 31 }, (_, i) => (
+                  {Array.from(
+                    { length: TIER_MAX - TIER_MIN + 1 },
+                    (_, i) => i + TIER_MIN
+                  ).map((i) => (
                     <SelectItem
                       key={i}
                       value={String(i)}

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -13,54 +13,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import cn from "@yeahx4/cn";
-
-const BASE_IMG =
-  "https://cdn.jsdelivr.net/gh/5tarlight/vlog-image@main/bjcord/solved-tier/";
-
-const TIER_COLORS: Record<number, string> = {
-  0: "#9d9d9d",
-  1: "#ad5600", 2: "#ad5600", 3: "#ad5600", 4: "#ad5600", 5: "#ad5600",
-  6: "#435f7a", 7: "#435f7a", 8: "#435f7a", 9: "#435f7a", 10: "#435f7a",
-  11: "#ec9b00", 12: "#ec9b00", 13: "#ec9b00", 14: "#ec9b00", 15: "#ec9b00",
-  16: "#27e2a4", 17: "#27e2a4", 18: "#27e2a4", 19: "#27e2a4", 20: "#27e2a4",
-  21: "#00b4fc", 22: "#00b4fc", 23: "#00b4fc", 24: "#00b4fc", 25: "#00b4fc",
-  26: "#ff0062", 27: "#ff0062", 28: "#ff0062", 29: "#ff0062", 30: "#ff0062",
-};
-
-/** 각 티어 경계 마커 (슬라이더용) */
-const TIER_MARKERS = [
-  { level: 0, img: "unrated", label: "Unrated" },
-  { level: 1, img: "bronze5", label: "Bronze V" },
-  { level: 6, img: "silver5", label: "Silver V" },
-  { level: 11, img: "gold5", label: "Gold V" },
-  { level: 16, img: "platinum5", label: "Plat V" },
-  { level: 21, img: "diamond5", label: "Diamond V" },
-  { level: 26, img: "ruby5", label: "Ruby V" },
-  { level: 30, img: "ruby1", label: "Ruby I" },
-] as const;
-
-function getTierColor(tier: number): string {
-  return TIER_COLORS[tier] ?? "#9d9d9d";
-}
-
-/** 티어 레벨(0~30)에 대응하는 이미지 파일명 반환 */
-function getTierImg(level: number): string {
-  if (level === 0) return "unrated";
-  const names = ["bronze", "silver", "gold", "platinum", "diamond", "ruby"];
-  const tierIdx = Math.ceil(level / 5) - 1;
-  const sub = 5 - ((level - 1) % 5);
-  return `${names[tierIdx]}${sub}`;
-}
-
-/**
- * WebKit 기준 슬라이더 thumb 중심 CSS 위치 계산
- * thumbDiameter=16px → offset = 8 - (level/30)*16
- */
-function thumbPos(level: number): string {
-  const pct = (level / 30) * 100;
-  const offset = 8 - (level / 30) * 16;
-  return `calc(${pct.toFixed(3)}% + ${offset.toFixed(3)}px)`;
-}
+import {
+  BASE_IMG,
+  getTierColor,
+  getTierImg,
+  thumbPos,
+  TIER_MARKERS,
+} from "@/lib/tier";
+import { useClickOutside } from "@/hooks/use-click-outside";
 
 /** 티어 이미지 + 이름을 함께 표시하는 셀렉트 아이템 row */
 function TierRow({ level }: { level: number }) {
@@ -70,9 +30,9 @@ function TierRow({ level }: { level: number }) {
         src={`${BASE_IMG}${getTierImg(level)}.png`}
         alt={TIER_NAME[level]}
         style={{ width: 16, height: 16, objectFit: "contain" }}
-      // onError={(e) => {
-      //   (e.target as HTMLImageElement).style.visibility = "hidden";
-      // }}
+        onError={(e) => {
+          (e.target as HTMLImageElement).style.display = "none";
+        }}
       />
       <span style={{ color: getTierColor(level) }}>{TIER_NAME[level]}</span>
     </span>
@@ -127,24 +87,12 @@ export default function TierRangeTooltip({
     setOpen(true);
   };
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      // Select가 열려 있는 동안에는 팝업을 닫지 않음
-      if (selectOpenRef.current > 0) return;
-      const t = e.target as Element;
-      // Radix Portal 내부 클릭 시 popup 닫지 않음
-      if (t.closest?.("[data-radix-popper-content-wrapper]")) return;
-      if (
-        popupRef.current && !popupRef.current.contains(t as Node) &&
-        triggerRef.current && !triggerRef.current.contains(t as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [open]);
+  useClickOutside(
+    open,
+    () => setOpen(false),
+    [popupRef, triggerRef],
+    () => selectOpenRef.current > 0
+  );
 
   const commitMin = (val: number) => {
     const v = Math.min(val, maxVal);
@@ -159,12 +107,13 @@ export default function TierRangeTooltip({
   const handleMinDrag = (val: number) => setMinVal(Math.min(val, maxVal));
   const handleMaxDrag = (val: number) => setMaxVal(Math.max(val, minVal));
 
-  const isDefault =
-    minVal === DEFAULT_TIER_SELECTOR_START &&
-    maxVal === DEFAULT_TIER_SELECTOR_END;
-
   const minPct = (minVal / 30) * 100;
   const maxPct = (maxVal / 30) * 100;
+
+  const onSelectOpenChange = (o: boolean) => {
+    if (o) selectOpenRef.current += 1;
+    else setTimeout(() => { selectOpenRef.current -= 1; }, 0);
+  };
 
   return (
     <>
@@ -172,33 +121,25 @@ export default function TierRangeTooltip({
       <button
         ref={triggerRef}
         onClick={handleOpen}
-        title={
-          isDefault
-            ? "전체 티어"
-            : `${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`
-        }
+        title={`${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`}
         className={cn(
           "text-[11px] px-2 py-0.5 rounded transition-colors w-full text-left truncate",
           "bg-[#1e1f22] hover:bg-[#36393f]",
           open ? "ring-1 ring-[#5865f2] text-white" : "text-gray-300"
         )}
       >
-        {isDefault ? (
-          <span className="text-gray-400">전체 티어</span>
-        ) : (
-          <>
-            <span style={{ color: getTierColor(minVal) }}>
-              {TIER_NAME[minVal]}
-            </span>
-            <span className="text-gray-500 mx-1">~</span>
-            <span style={{ color: getTierColor(maxVal) }}>
-              {TIER_NAME[maxVal]}
-            </span>
-          </>
-        )}
+        <>
+          <span style={{ color: getTierColor(minVal) }}>
+            {TIER_NAME[minVal]}
+          </span>
+          <span className="text-gray-500 mx-1">~</span>
+          <span style={{ color: getTierColor(maxVal) }}>
+            {TIER_NAME[maxVal]}
+          </span>
+        </>
       </button>
 
-      {/* 오버레이 팝업 (fixed, 레이아웃 시프트 없음) */}
+      {/* 오버레이 팝업 */}
       {open && (
         <div
           ref={popupRef}
@@ -212,7 +153,7 @@ export default function TierRangeTooltip({
         >
           {/* 헤더 */}
           <div className="flex items-center justify-between mb-4">
-            <span className="text-sm font-bold text-white">전송할 티어 범위 설정</span>
+            <span className="text-sm font-bold text-white">전송할 난이도 범위 설정</span>
             <button
               onClick={() => setOpen(false)}
               className="text-gray-400 hover:text-white text-xs transition-colors leading-none"
@@ -257,7 +198,7 @@ export default function TierRangeTooltip({
             </div>
 
             {/* ── 티어 마커 (점 + 아이콘) ── */}
-            <div className="relative mt-1" style={{ height: 44 }}>
+            <div className="relative mt-1 px-[10px]" style={{ height: 44 }}>
               {TIER_MARKERS.map(({ level, img, label }) => {
                 const isActive = level >= minVal && level <= maxVal;
                 return (
@@ -271,7 +212,7 @@ export default function TierRangeTooltip({
                     }}
                   >
                     <div
-                      className="w-1.5 h-1.5 rounded-full mb-0.5 transition-colors"
+                      className="w-1.5 h-1.5 rounded-full mb-0.75 transition-colors"
                       style={{
                         backgroundColor: isActive
                           ? getTierColor(level)
@@ -282,15 +223,13 @@ export default function TierRangeTooltip({
                       src={`${BASE_IMG}${img}.png`}
                       alt={label}
                       title={label}
-                      className="transition-opacity"
+                      className="transition-opacity w-5 h-5 object-contain"
                       style={{
-                        width: 20, height: 20,
-                        objectFit: "contain",
                         opacity: isActive ? 1 : 0.25,
                       }}
-                    // onError={(e) => {
-                    //   (e.target as HTMLImageElement).style.display = "none";
-                    // }}
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = "none";
+                      }}
                     />
                   </div>
                 );
@@ -298,7 +237,7 @@ export default function TierRangeTooltip({
             </div>
           </div>
 
-          {/* ── 드롭다운 (Radix Select + 티어 이미지) ── */}
+          {/* 드롭다운 (Radix Select + 티어 이미지) */}
           <div className="flex gap-3 items-end mt-4">
             {/* 하한 */}
             <div className="flex-1">
@@ -308,10 +247,7 @@ export default function TierRangeTooltip({
               <Select
                 value={String(minVal)}
                 onValueChange={(v) => commitMin(Number(v))}
-                onOpenChange={(o) => {
-                  if (o) selectOpenRef.current += 1;
-                  else setTimeout(() => { selectOpenRef.current -= 1; }, 0);
-                }}
+                onOpenChange={onSelectOpenChange}
               >
                 <SelectTrigger
                   size="sm"
@@ -346,10 +282,7 @@ export default function TierRangeTooltip({
               <Select
                 value={String(maxVal)}
                 onValueChange={(v) => commitMax(Number(v))}
-                onOpenChange={(o) => {
-                  if (o) selectOpenRef.current += 1;
-                  else setTimeout(() => { selectOpenRef.current -= 1; }, 0);
-                }}
+                onOpenChange={onSelectOpenChange}
               >
                 <SelectTrigger
                   size="sm"

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -21,6 +21,7 @@ import {
   TIER_MARKERS,
 } from "@/lib/tier";
 import { useClickOutside } from "@/hooks/use-click-outside";
+import { syncTierSelector } from "@/lib/browser";
 
 /** 티어 이미지 + 이름을 함께 표시하는 셀렉트 아이템 row */
 function TierRow({ level }: { level: number }) {
@@ -98,11 +99,13 @@ export default function TierRangeTooltip({
     const v = Math.min(val, maxVal);
     setMinVal(v);
     handleUpdateWebhook(webhook.id, { tierMin: v });
+    syncTierSelector(v, maxVal);
   };
   const commitMax = (val: number) => {
     const v = Math.max(val, minVal);
     setMaxVal(v);
     handleUpdateWebhook(webhook.id, { tierMax: v });
+    syncTierSelector(minVal, v);
   };
   const handleMinDrag = (val: number) => setMinVal(Math.min(val, maxVal));
   const handleMaxDrag = (val: number) => setMaxVal(Math.max(val, minVal));

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -1,0 +1,381 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  DEFAULT_TIER_SELECTOR_END,
+  DEFAULT_TIER_SELECTOR_START,
+  TIER_NAME,
+} from "@/lib/constants";
+import { Webhook } from "@/lib/webhook";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import cn from "@yeahx4/cn";
+
+const BASE_IMG =
+  "https://cdn.jsdelivr.net/gh/5tarlight/vlog-image@main/bjcord/solved-tier/";
+
+const TIER_COLORS: Record<number, string> = {
+  0: "#9d9d9d",
+  1: "#ad5600", 2: "#ad5600", 3: "#ad5600", 4: "#ad5600", 5: "#ad5600",
+  6: "#435f7a", 7: "#435f7a", 8: "#435f7a", 9: "#435f7a", 10: "#435f7a",
+  11: "#ec9b00", 12: "#ec9b00", 13: "#ec9b00", 14: "#ec9b00", 15: "#ec9b00",
+  16: "#27e2a4", 17: "#27e2a4", 18: "#27e2a4", 19: "#27e2a4", 20: "#27e2a4",
+  21: "#00b4fc", 22: "#00b4fc", 23: "#00b4fc", 24: "#00b4fc", 25: "#00b4fc",
+  26: "#ff0062", 27: "#ff0062", 28: "#ff0062", 29: "#ff0062", 30: "#ff0062",
+};
+
+/** 각 티어 경계 마커 (슬라이더용) */
+const TIER_MARKERS = [
+  { level: 0, img: "unrated", label: "Unrated" },
+  { level: 1, img: "bronze5", label: "Bronze V" },
+  { level: 6, img: "silver5", label: "Silver V" },
+  { level: 11, img: "gold5", label: "Gold V" },
+  { level: 16, img: "platinum5", label: "Plat V" },
+  { level: 21, img: "diamond5", label: "Diamond V" },
+  { level: 26, img: "ruby5", label: "Ruby V" },
+  { level: 30, img: "ruby1", label: "Ruby I" },
+] as const;
+
+function getTierColor(tier: number): string {
+  return TIER_COLORS[tier] ?? "#9d9d9d";
+}
+
+/** 티어 레벨(0~30)에 대응하는 이미지 파일명 반환 */
+function getTierImg(level: number): string {
+  if (level === 0) return "unrated";
+  const names = ["bronze", "silver", "gold", "platinum", "diamond", "ruby"];
+  const tierIdx = Math.ceil(level / 5) - 1;
+  const sub = 5 - ((level - 1) % 5);
+  return `${names[tierIdx]}${sub}`;
+}
+
+/**
+ * WebKit 기준 슬라이더 thumb 중심 CSS 위치 계산
+ * thumbDiameter=16px → offset = 8 - (level/30)*16
+ */
+function thumbPos(level: number): string {
+  const pct = (level / 30) * 100;
+  const offset = 8 - (level / 30) * 16;
+  return `calc(${pct.toFixed(3)}% + ${offset.toFixed(3)}px)`;
+}
+
+/** 티어 이미지 + 이름을 함께 표시하는 셀렉트 아이템 row */
+function TierRow({ level }: { level: number }) {
+  return (
+    <span className="flex items-center gap-2">
+      <img
+        src={`${BASE_IMG}${getTierImg(level)}.png`}
+        alt={TIER_NAME[level]}
+        style={{ width: 16, height: 16, objectFit: "contain" }}
+      // onError={(e) => {
+      //   (e.target as HTMLImageElement).style.visibility = "hidden";
+      // }}
+      />
+      <span style={{ color: getTierColor(level) }}>{TIER_NAME[level]}</span>
+    </span>
+  );
+}
+
+export default function TierRangeTooltip({
+  webhook,
+  handleUpdateWebhook,
+}: {
+  webhook: Webhook;
+  handleUpdateWebhook: (
+    id: string,
+    updates: Partial<Omit<Webhook, "id">>
+  ) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selectOpenRef = useRef(0);
+  const [minVal, setMinVal] = useState(
+    webhook.tierMin ?? DEFAULT_TIER_SELECTOR_START
+  );
+  const [maxVal, setMaxVal] = useState(
+    webhook.tierMax ?? DEFAULT_TIER_SELECTOR_END
+  );
+  const [popupStyle, setPopupStyle] = useState<React.CSSProperties>({});
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMinVal(webhook.tierMin ?? DEFAULT_TIER_SELECTOR_START);
+    setMaxVal(webhook.tierMax ?? DEFAULT_TIER_SELECTOR_END);
+  }, [webhook.tierMin, webhook.tierMax]);
+
+  const calcPopupStyle = (): React.CSSProperties => {
+    if (!triggerRef.current) return {};
+    const rect = triggerRef.current.getBoundingClientRect();
+    const popupWidth = 360;
+    const popupHeight = 340;
+    const margin = 8;
+    let left = rect.left;
+    let top = rect.bottom + margin;
+    if (left + popupWidth > window.innerWidth - 8)
+      left = Math.max(8, window.innerWidth - popupWidth - 8);
+    if (top + popupHeight > window.innerHeight - 8)
+      top = rect.top - popupHeight - margin;
+    return { top, left, width: popupWidth };
+  };
+
+  const handleOpen = () => {
+    setPopupStyle(calcPopupStyle());
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      // Select가 열려 있는 동안에는 팝업을 닫지 않음
+      if (selectOpenRef.current > 0) return;
+      const t = e.target as Element;
+      // Radix Portal 내부 클릭 시 popup 닫지 않음
+      if (t.closest?.("[data-radix-popper-content-wrapper]")) return;
+      if (
+        popupRef.current && !popupRef.current.contains(t as Node) &&
+        triggerRef.current && !triggerRef.current.contains(t as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  const commitMin = (val: number) => {
+    const v = Math.min(val, maxVal);
+    setMinVal(v);
+    handleUpdateWebhook(webhook.id, { tierMin: v });
+  };
+  const commitMax = (val: number) => {
+    const v = Math.max(val, minVal);
+    setMaxVal(v);
+    handleUpdateWebhook(webhook.id, { tierMax: v });
+  };
+  const handleMinDrag = (val: number) => setMinVal(Math.min(val, maxVal));
+  const handleMaxDrag = (val: number) => setMaxVal(Math.max(val, minVal));
+
+  const isDefault =
+    minVal === DEFAULT_TIER_SELECTOR_START &&
+    maxVal === DEFAULT_TIER_SELECTOR_END;
+
+  const minPct = (minVal / 30) * 100;
+  const maxPct = (maxVal / 30) * 100;
+
+  return (
+    <>
+      {/* 트리거 버튼 */}
+      <button
+        ref={triggerRef}
+        onClick={handleOpen}
+        title={
+          isDefault
+            ? "전체 티어"
+            : `${TIER_NAME[minVal]} ~ ${TIER_NAME[maxVal]}`
+        }
+        className={cn(
+          "text-[11px] px-2 py-0.5 rounded transition-colors w-full text-left truncate",
+          "bg-[#1e1f22] hover:bg-[#36393f]",
+          open ? "ring-1 ring-[#5865f2] text-white" : "text-gray-300"
+        )}
+      >
+        {isDefault ? (
+          <span className="text-gray-400">전체 티어</span>
+        ) : (
+          <>
+            <span style={{ color: getTierColor(minVal) }}>
+              {TIER_NAME[minVal]}
+            </span>
+            <span className="text-gray-500 mx-1">~</span>
+            <span style={{ color: getTierColor(maxVal) }}>
+              {TIER_NAME[maxVal]}
+            </span>
+          </>
+        )}
+      </button>
+
+      {/* 오버레이 팝업 (fixed, 레이아웃 시프트 없음) */}
+      {open && (
+        <div
+          ref={popupRef}
+          style={popupStyle}
+          className={cn(
+            "fixed z-[9999]",
+            "bg-[#2c2f33] border border-[#5865f2]",
+            "rounded-xl shadow-2xl",
+            "p-6"
+          )}
+        >
+          {/* 헤더 */}
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-sm font-bold text-white">전송할 티어 범위 설정</span>
+            <button
+              onClick={() => setOpen(false)}
+              className="text-gray-400 hover:text-white text-xs transition-colors leading-none"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* 현재 선택 표시 */}
+          <div className="flex justify-between text-xs mb-5 px-1">
+            <span className="font-semibold" style={{ color: getTierColor(minVal) }}>
+              {TIER_NAME[minVal]}
+            </span>
+            <span className="text-gray-500">~</span>
+            <span className="font-semibold" style={{ color: getTierColor(maxVal) }}>
+              {TIER_NAME[maxVal]}
+            </span>
+          </div>
+
+          {/* ── 슬라이더 영역 ── */}
+          <div className="px-1">
+            <div className="relative h-5 flex items-center">
+              <div className="absolute w-full h-1.5 rounded-full bg-[#4f545c]" />
+              <div
+                className="absolute h-1.5 rounded-full bg-[#5865f2]"
+                style={{ left: `${minPct}%`, right: `${100 - maxPct}%` }}
+              />
+              <input
+                type="range" min={0} max={30} value={minVal}
+                onChange={(e) => handleMinDrag(Number(e.target.value))}
+                onMouseUp={(e) => commitMin(Number((e.target as HTMLInputElement).value))}
+                className="dual-range-input"
+                style={{ zIndex: minVal > 28 ? 5 : 3 }}
+              />
+              <input
+                type="range" min={0} max={30} value={maxVal}
+                onChange={(e) => handleMaxDrag(Number(e.target.value))}
+                onMouseUp={(e) => commitMax(Number((e.target as HTMLInputElement).value))}
+                className="dual-range-input"
+                style={{ zIndex: 4 }}
+              />
+            </div>
+
+            {/* ── 티어 마커 (점 + 아이콘) ── */}
+            <div className="relative mt-1" style={{ height: 44 }}>
+              {TIER_MARKERS.map(({ level, img, label }) => {
+                const isActive = level >= minVal && level <= maxVal;
+                return (
+                  <div
+                    key={level}
+                    className="absolute flex flex-col items-center"
+                    style={{
+                      left: thumbPos(level),
+                      transform: "translateX(-50%)",
+                      top: 0,
+                    }}
+                  >
+                    <div
+                      className="w-1.5 h-1.5 rounded-full mb-0.5 transition-colors"
+                      style={{
+                        backgroundColor: isActive
+                          ? getTierColor(level)
+                          : "#4f545c",
+                      }}
+                    />
+                    <img
+                      src={`${BASE_IMG}${img}.png`}
+                      alt={label}
+                      title={label}
+                      className="transition-opacity"
+                      style={{
+                        width: 20, height: 20,
+                        objectFit: "contain",
+                        opacity: isActive ? 1 : 0.25,
+                      }}
+                    // onError={(e) => {
+                    //   (e.target as HTMLImageElement).style.display = "none";
+                    // }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* ── 드롭다운 (Radix Select + 티어 이미지) ── */}
+          <div className="flex gap-3 items-end mt-4">
+            {/* 하한 */}
+            <div className="flex-1">
+              <label className="block text-[10px] text-gray-400 mb-1.5 font-medium">
+                하한
+              </label>
+              <Select
+                value={String(minVal)}
+                onValueChange={(v) => commitMin(Number(v))}
+                onOpenChange={(o) => {
+                  if (o) selectOpenRef.current += 1;
+                  else setTimeout(() => { selectOpenRef.current -= 1; }, 0);
+                }}
+              >
+                <SelectTrigger
+                  size="sm"
+                  className="w-full bg-[#1e1f22] border-[#4f545c] text-white text-xs h-8 focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                >
+                  <SelectValue>
+                    <TierRow level={minVal} />
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent className="bg-[#1e1f22] border-[#4f545c] text-white max-h-56 z-[99999]">
+                  {Array.from({ length: 31 }, (_, i) => (
+                    <SelectItem
+                      key={i}
+                      value={String(i)}
+                      disabled={i > maxVal}
+                      className="text-xs focus:bg-[#36393f] focus:text-white data-[disabled]:opacity-30"
+                    >
+                      <TierRow level={i} />
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <span className="text-gray-500 pb-1.5 text-sm">~</span>
+
+            {/* 상한 */}
+            <div className="flex-1">
+              <label className="block text-[10px] text-gray-400 mb-1.5 font-medium">
+                상한
+              </label>
+              <Select
+                value={String(maxVal)}
+                onValueChange={(v) => commitMax(Number(v))}
+                onOpenChange={(o) => {
+                  if (o) selectOpenRef.current += 1;
+                  else setTimeout(() => { selectOpenRef.current -= 1; }, 0);
+                }}
+              >
+                <SelectTrigger
+                  size="sm"
+                  className="w-full bg-[#1e1f22] border-[#4f545c] text-white text-xs h-8 focus-visible:ring-[#5865f2]/50 focus-visible:border-[#5865f2]"
+                >
+                  <SelectValue>
+                    <TierRow level={maxVal} />
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent className="bg-[#1e1f22] border-[#4f545c] text-white max-h-56 z-[99999]">
+                  {Array.from({ length: 31 }, (_, i) => (
+                    <SelectItem
+                      key={i}
+                      value={String(i)}
+                      disabled={i < minVal}
+                      className="text-xs focus:bg-[#36393f] focus:text-white data-[disabled]:opacity-30"
+                    >
+                      <TierRow level={i} />
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/options/tier-range-tooltip.tsx
+++ b/components/options/tier-range-tooltip.tsx
@@ -21,7 +21,6 @@ import {
   TIER_MARKERS,
 } from "@/lib/tier";
 import { useClickOutside } from "@/hooks/use-click-outside";
-import { syncTierSelector } from "@/lib/browser";
 
 /** 티어 이미지 + 이름을 함께 표시하는 셀렉트 아이템 row */
 function TierRow({ level }: { level: number }) {
@@ -99,13 +98,13 @@ export default function TierRangeTooltip({
     const v = Math.min(val, maxVal);
     setMinVal(v);
     handleUpdateWebhook(webhook.id, { tierMin: v });
-    syncTierSelector(v, maxVal);
+
   };
   const commitMax = (val: number) => {
     const v = Math.max(val, minVal);
     setMaxVal(v);
     handleUpdateWebhook(webhook.id, { tierMax: v });
-    syncTierSelector(minVal, v);
+
   };
   const handleMinDrag = (val: number) => setMinVal(Math.min(val, maxVal));
   const handleMaxDrag = (val: number) => setMaxVal(Math.max(val, minVal));

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,185 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/shadcn-utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -4,6 +4,10 @@ import OptionWebhookItem from "@/components/options/option-webhook-item";
 import PopupTitle from "@/components/popup/title";
 import {getWebhooks, initStorage } from "@/lib/browser";
 import {
+  DEFAULT_TIER_SELECTION_END,
+  DEFAULT_TIER_SELECTION_START,
+} from "@/lib/constants";
+import {
   addWebhook,
   createWebhook,
   deleteWebhook,
@@ -17,6 +21,9 @@ function App() {
   const [nameInput, setNameInput] = useState("");
   const [urlInput, setUrlInput] = useState("");
   const [displayNameInput, setDisplayNameInput] = useState("");
+  const [tierMinInput, setTierMinInput] = useState(DEFAULT_TIER_SELECTION_START);
+  const [tierMaxInput, setTierMaxInput] = useState(DEFAULT_TIER_SELECTION_END);
+  const [includeUnratedInput, setIncludeUnratedInput] = useState(true);
 
   useEffect(() => {
     (async () => {
@@ -31,13 +38,17 @@ function App() {
       nameInput,
       urlInput,
       displayNameInput,
-      0,
-      30
+      tierMinInput,
+      tierMaxInput,
+      includeUnratedInput
     );
     setWebhooks((prev) => [...prev, newWebhook]);
     setNameInput("");
     setUrlInput("");
     setDisplayNameInput("");
+    setTierMinInput(DEFAULT_TIER_SELECTION_START);
+    setTierMaxInput(DEFAULT_TIER_SELECTION_END);
+    setIncludeUnratedInput(true);
 
     await addWebhook(newWebhook);
   };
@@ -89,9 +100,13 @@ function App() {
             setUrlInput={setUrlInput}
             displayNameInput={displayNameInput}
             setDisplayNameInput={setDisplayNameInput}
+            tierMinInput={tierMinInput}
+            setTierMinInput={setTierMinInput}
+            tierMaxInput={tierMaxInput}
+            setTierMaxInput={setTierMaxInput}
+            includeUnratedInput={includeUnratedInput}
+            setIncludeUnratedInput={setIncludeUnratedInput}
             handleAddWebhook={handleAddWebhook}
-            handleDeleteWebhook={handleDeleteWebhook}
-            handleUpdateWebhook={handleUpdateWebhook}
           />
         </div>
       </div>

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -2,7 +2,7 @@ import OptionHeader from "@/components/options/option-header";
 import OptionInputField from "@/components/options/option-input-field";
 import OptionWebhookItem from "@/components/options/option-webhook-item";
 import PopupTitle from "@/components/popup/title";
-import { getTierSelector, getWebhooks, initStorage } from "@/lib/browser";
+import {getWebhooks, initStorage } from "@/lib/browser";
 import {
   addWebhook,
   createWebhook,
@@ -27,13 +27,12 @@ function App() {
 
   const handleAddWebhook = async () => {
     if (!nameInput || !urlInput) return;
-    const { start, end } = await getTierSelector();
     const newWebhook = createWebhook(
       nameInput,
       urlInput,
       displayNameInput,
-      start,
-      end
+      0,
+      30
     );
     setWebhooks((prev) => [...prev, newWebhook]);
     setNameInput("");

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -2,7 +2,7 @@ import OptionHeader from "@/components/options/option-header";
 import OptionInputField from "@/components/options/option-input-field";
 import OptionWebhookItem from "@/components/options/option-webhook-item";
 import PopupTitle from "@/components/popup/title";
-import { getWebhooks, initStorage } from "@/lib/browser";
+import { getTierSelector, getWebhooks, initStorage } from "@/lib/browser";
 import {
   addWebhook,
   createWebhook,
@@ -27,7 +27,14 @@ function App() {
 
   const handleAddWebhook = async () => {
     if (!nameInput || !urlInput) return;
-    const newWebhook = createWebhook(nameInput, urlInput, displayNameInput);
+    const { start, end } = await getTierSelector();
+    const newWebhook = createWebhook(
+      nameInput,
+      urlInput,
+      displayNameInput,
+      start,
+      end
+    );
     setWebhooks((prev) => [...prev, newWebhook]);
     setNameInput("");
     setUrlInput("");

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -8,3 +8,45 @@ body {
   background-color: #1e2124;
   color: white;
 }
+
+/* 듀얼 레인지 슬라이더 */
+.dual-range-input {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  pointer-events: none;
+  outline: none;
+}
+
+.dual-range-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  cursor: pointer;
+  pointer-events: auto;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  border: 2px solid #5865f2;
+  transition: transform 0.1s, box-shadow 0.1s;
+}
+
+.dual-range-input::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+  box-shadow: 0 2px 8px rgba(88, 101, 242, 0.6);
+}
+
+.dual-range-input::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  cursor: pointer;
+  pointer-events: auto;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  border: 2px solid #5865f2;
+}

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "../../global.css";
 
 body {
   width: 100vw;

--- a/global.css
+++ b/global.css
@@ -1,0 +1,123 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.145 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.145 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/hooks/use-click-outside.ts
+++ b/hooks/use-click-outside.ts
@@ -1,0 +1,34 @@
+import { RefObject, useEffect } from "react";
+
+/**
+ * 지정된 ref 외부를 mousedown 클릭 시 콜백을 호출하는 훅.
+ * - Radix UI 포털([data-radix-popper-content-wrapper]) 내부 클릭은 무시.
+ * - shouldBlock() 이 true 를 반환하면 (예: Select 열림 중) 콜백을 호출하지 않음.
+ */
+export function useClickOutside(
+  enabled: boolean,
+  onClickOutside: () => void,
+  ignoredRefs: RefObject<Element | null>[],
+  shouldBlock?: () => boolean
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (shouldBlock?.()) return;
+
+      const t = e.target as Element;
+      if (t.closest?.("[data-radix-popper-content-wrapper]")) return;
+
+      const isInsideIgnored = ignoredRefs.some((ref) =>
+        ref.current?.contains(t as Node)
+      );
+      if (!isInsideIgnored) onClickOutside();
+    };
+
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+    // ignoredRefs 배열 자체가 매 렌더마다 새 참조이므로 의도적으로 제외
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+}

--- a/lib/boj.ts
+++ b/lib/boj.ts
@@ -19,6 +19,8 @@ import {
   SUBMISSION_TIME_QUERY,
   TIER_NAME,
   WATCH_JUDGEMENT_INTERVAL,
+  DEFAULT_TIER_SELECTION_END,
+  DEFAULT_TIER_SELECTION_START,
 } from "./constants";
 import { Logger } from "./logger";
 
@@ -540,8 +542,11 @@ export async function watchJudgementChange(
       const webhooks = (await getWebhooks()).filter((wh) => {
         if (!wh.active) return false;
         const level = webhookData.level;
-        const min = wh.tierMin ?? 0;
-        const max = wh.tierMax ?? 30;
+        const includeUnrated = wh.includeUnrated ?? wh.tierMin === 0;
+        const min = wh.tierMin ?? DEFAULT_TIER_SELECTION_START;
+        const max = wh.tierMax ?? DEFAULT_TIER_SELECTION_END;
+
+        if (level === 0) return includeUnrated;
         return level >= min && level <= max;
       });
       let success = 0;

--- a/lib/boj.ts
+++ b/lib/boj.ts
@@ -374,69 +374,71 @@ export async function getWebhookMessage(
 
   const tier = getProblemTier(solved);
 
-  return (displayName: string | undefined) => ({
-    content: null,
-    embeds: [
-      {
-        title: `[${tier}] ${problemId}번: ${solved.titleKo}`,
-        url: `https://www.acmicpc.net/problem/${problemId}`,
-        description: `[코드 보기](https://www.acmicpc.net/source/${submissionId})\n${
-          solved.tags.length > 0
-            ? `태그: ||${solved.tags.map(getTagName).join(", ")}||`
-            : ""
-        }`,
-        color: getColor(tier.split(" ")[0].toLowerCase()),
-        fields: [
-          {
-            name: "성능",
-            value: `${memory} KB / ${runtime} ms`,
-            inline: true,
+  return {
+    level: solved.level,
+    buildMessage: (displayName: string | undefined) => ({
+      content: null,
+      embeds: [
+        {
+          title: `[${tier}] ${problemId}번: ${solved.titleKo}`,
+          url: `https://www.acmicpc.net/problem/${problemId}`,
+          description: `[코드 보기](https://www.acmicpc.net/source/${submissionId})\n${solved.tags.length > 0
+              ? `태그: ||${solved.tags.map(getTagName).join(", ")}||`
+              : ""
+            }`,
+          color: getColor(tier.split(" ")[0].toLowerCase()),
+          fields: [
+            {
+              name: "성능",
+              value: `${memory} KB / ${runtime} ms`,
+              inline: true,
+            },
+            {
+              name: "언어",
+              value: language || "?",
+              inline: true,
+            },
+            {
+              name: "시도한 횟수",
+              value: `${attempts} 회`,
+              inline: true,
+            },
+            {
+              name: "제출 일자",
+              value: `${timestamp}`,
+              inline: true,
+            },
+            {
+              name: "코드 길이",
+              value: length ? `${length} B` : "?",
+              inline: true,
+            },
+            {
+              name: "평균 시도",
+              value: `${solved.averageTries} 회`,
+              inline: true,
+            },
+            {
+              name: "맞은 사람",
+              value: `${solved.acceptedUserCount} 명`,
+              inline: true,
+            },
+          ],
+          author: {
+            name: `${displayName || handle}`,
+            url: `https://solved.ac/profile/${handle}`,
           },
-          {
-            name: "언어",
-            value: language || "?",
-            inline: true,
+          thumbnail: {
+            url: getLevelImg(tier),
           },
-          {
-            name: "시도한 횟수",
-            value: `${attempts} 회`,
-            inline: true,
-          },
-          {
-            name: "제출 일자",
-            value: `${timestamp}`,
-            inline: true,
-          },
-          {
-            name: "코드 길이",
-            value: length ? `${length} B` : "?",
-            inline: true,
-          },
-          {
-            name: "평균 시도",
-            value: `${solved.averageTries} 회`,
-            inline: true,
-          },
-          {
-            name: "맞은 사람",
-            value: `${solved.acceptedUserCount} 명`,
-            inline: true,
-          },
-        ],
-        author: {
-          name: `${displayName || handle}`,
-          url: `https://solved.ac/profile/${handle}`,
         },
-        thumbnail: {
-          url: getLevelImg(tier),
-        },
-      },
-    ],
-    username: "BJCORD",
-    avatar_url:
-      "https://cdn.jsdelivr.net/gh/5tarlight/vlog-image@main/bjcord/thumbnail.png",
-    attachments: [],
-  });
+      ],
+      username: "BJCORD",
+      avatar_url:
+        "https://cdn.jsdelivr.net/gh/5tarlight/vlog-image@main/bjcord/thumbnail.png",
+      attachments: [],
+    }),
+  };
 }
 
 /**
@@ -521,7 +523,7 @@ export async function watchJudgementChange(
     logger.log(`Sending webhook...`);
 
     (async () => {
-      const msg = await getWebhookMessage(
+      const webhookData = await getWebhookMessage(
         latest.username,
         latest.submissionId,
         latest.problemId,
@@ -535,12 +537,18 @@ export async function watchJudgementChange(
         attempts
       );
 
-      const webhooks = (await getWebhooks()).filter((wh) => wh.active);
+      const webhooks = (await getWebhooks()).filter((wh) => {
+        if (!wh.active) return false;
+        const level = webhookData.level;
+        const min = wh.tierMin ?? 0;
+        const max = wh.tierMax ?? 30;
+        return level >= min && level <= max;
+      });
       let success = 0;
       let failure = 0;
       for (const webhook of webhooks) {
         try {
-          await sendMessage(msg(webhook.displayName), webhook.url);
+          await sendMessage(webhookData.buildMessage(webhook.displayName), webhook.url);
           success++;
         } catch (e) {
           logger.error(e);

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -5,7 +5,6 @@ import {
   SHOW_EMOJI_KEY,
   WEBHOOK_KEY,
 
-  TIER_SELECTOR_KEY,
   DEFAULT_TIER_SELECTOR_START,
   DEFAULT_TIER_SELECTOR_END,
 } from "./constants";
@@ -165,28 +164,6 @@ export const syncSendFirstAcOnly = async (onlyFirst: boolean) => {
   await browser.storage.sync.set({ [SEND_FIRST_AC_ONLY_KEY]: onlyFirst });
 };
 
-export const getTierSelector = async (): Promise<{ start: number; end: number }> => {
-  const storage = await browser.storage.sync.get(TIER_SELECTOR_KEY);
-  const tierSelector = storage[TIER_SELECTOR_KEY];
-  if (
-    tierSelector === undefined ||
-    tierSelector.start === undefined ||
-    tierSelector.end === undefined
-  ) {
-    return {
-      start: DEFAULT_TIER_SELECTOR_START,
-      end: DEFAULT_TIER_SELECTOR_END,
-    };
-  }
-  return tierSelector;
-};
-
-export const syncTierSelector = async (start: number, end: number) => {
-  await browser.storage.sync.set({
-    [TIER_SELECTOR_KEY]: { start, end },
-  });
-};
-
 /**
  * 확장 프로그램이 처음 실행되는지 여부를 반환합니다.
  * 웹훅, 이모지 표시 여부, 첫 AC만 전송 여부 설정이 존재하지 않는 경우(undefined)
@@ -201,14 +178,12 @@ export const isFirstRun = async (): Promise<boolean> => {
     WEBHOOK_KEY,
     SHOW_EMOJI_KEY,
     SEND_FIRST_AC_ONLY_KEY,
-    TIER_SELECTOR_KEY,
   ]);
 
   return (
     storage[WEBHOOK_KEY] === undefined ||
     storage[SHOW_EMOJI_KEY] === undefined ||
-    storage[SEND_FIRST_AC_ONLY_KEY] === undefined ||
-    storage[TIER_SELECTOR_KEY] === undefined
+    storage[SEND_FIRST_AC_ONLY_KEY] === undefined
   );
 };
 
@@ -223,7 +198,6 @@ export const initStorage = async () => {
     WEBHOOK_KEY,
     SHOW_EMOJI_KEY,
     SEND_FIRST_AC_ONLY_KEY,
-    TIER_SELECTOR_KEY,
   ]);
 
   if (storage[WEBHOOK_KEY] === undefined)
@@ -235,13 +209,5 @@ export const initStorage = async () => {
   if (storage[SEND_FIRST_AC_ONLY_KEY] === undefined)
     await browser.storage.sync.set({
       [SEND_FIRST_AC_ONLY_KEY]: DEFAULT_SEND_FIRST_AC_ONLY,
-    });
-
-  if (storage[TIER_SELECTOR_KEY] === undefined)
-    await browser.storage.sync.set({
-      [TIER_SELECTOR_KEY]: {
-        start: DEFAULT_TIER_SELECTOR_START,
-        end: DEFAULT_TIER_SELECTOR_END,
-      },
     });
 };

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -4,6 +4,10 @@ import {
   SEND_FIRST_AC_ONLY_KEY,
   SHOW_EMOJI_KEY,
   WEBHOOK_KEY,
+
+  TIER_SELECTOR_KEY,
+  DEFAULT_TIER_SELECTOR_START,
+  DEFAULT_TIER_SELECTOR_END,
 } from "./constants";
 import { createUUID } from "./util";
 import { Webhook } from "./webhook";
@@ -161,6 +165,28 @@ export const syncSendFirstAcOnly = async (onlyFirst: boolean) => {
   await browser.storage.sync.set({ [SEND_FIRST_AC_ONLY_KEY]: onlyFirst });
 };
 
+export const getTierSelector = async (): Promise<{ start: number; end: number }> => {
+  const storage = await browser.storage.sync.get(TIER_SELECTOR_KEY);
+  const tierSelector = storage[TIER_SELECTOR_KEY];
+  if (
+    tierSelector === undefined ||
+    tierSelector.start === undefined ||
+    tierSelector.end === undefined
+  ) {
+    return {
+      start: DEFAULT_TIER_SELECTOR_START,
+      end: DEFAULT_TIER_SELECTOR_END,
+    };
+  }
+  return tierSelector;
+};
+
+export const syncTierSelector = async (start: number, end: number) => {
+  await browser.storage.sync.set({
+    [TIER_SELECTOR_KEY]: { start, end },
+  });
+};
+
 /**
  * 확장 프로그램이 처음 실행되는지 여부를 반환합니다.
  * 웹훅, 이모지 표시 여부, 첫 AC만 전송 여부 설정이 존재하지 않는 경우(undefined)
@@ -176,11 +202,13 @@ export const isFirstRun = async (): Promise<boolean> => {
   const sendFirstAcOnly = await browser.storage.sync.get(
     SEND_FIRST_AC_ONLY_KEY
   );
+  const tierSelector = await browser.storage.sync.get(TIER_SELECTOR_KEY);
 
   return (
     webhooks[WEBHOOK_KEY] === undefined ||
     shouldShowEmoji[SHOW_EMOJI_KEY] === undefined ||
-    sendFirstAcOnly[SEND_FIRST_AC_ONLY_KEY] === undefined
+    sendFirstAcOnly[SEND_FIRST_AC_ONLY_KEY] === undefined ||
+    tierSelector[TIER_SELECTOR_KEY] === undefined
   );
 };
 
@@ -200,5 +228,13 @@ export const initStorage = async () => {
   if ((await browser.storage.sync.get(SEND_FIRST_AC_ONLY_KEY)) === undefined)
     await browser.storage.sync.set({
       [SEND_FIRST_AC_ONLY_KEY]: DEFAULT_SEND_FIRST_AC_ONLY,
+    });
+    
+  if ((await browser.storage.sync.get(TIER_SELECTOR_KEY)) === undefined)
+    await browser.storage.sync.set({
+      [TIER_SELECTOR_KEY]: {
+        start: DEFAULT_TIER_SELECTOR_START,
+        end: DEFAULT_TIER_SELECTOR_END,
+      },
     });
 };

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -197,18 +197,18 @@ export const syncTierSelector = async (start: number, end: number) => {
  * @returns 확장 프로그램이 처음 실행되는지 여부
  */
 export const isFirstRun = async (): Promise<boolean> => {
-  const webhooks = await browser.storage.sync.get(WEBHOOK_KEY);
-  const shouldShowEmoji = await browser.storage.sync.get(SHOW_EMOJI_KEY);
-  const sendFirstAcOnly = await browser.storage.sync.get(
-    SEND_FIRST_AC_ONLY_KEY
-  );
-  const tierSelector = await browser.storage.sync.get(TIER_SELECTOR_KEY);
+  const storage = await browser.storage.sync.get([
+    WEBHOOK_KEY,
+    SHOW_EMOJI_KEY,
+    SEND_FIRST_AC_ONLY_KEY,
+    TIER_SELECTOR_KEY,
+  ]);
 
   return (
-    webhooks[WEBHOOK_KEY] === undefined ||
-    shouldShowEmoji[SHOW_EMOJI_KEY] === undefined ||
-    sendFirstAcOnly[SEND_FIRST_AC_ONLY_KEY] === undefined ||
-    tierSelector[TIER_SELECTOR_KEY] === undefined
+    storage[WEBHOOK_KEY] === undefined ||
+    storage[SHOW_EMOJI_KEY] === undefined ||
+    storage[SEND_FIRST_AC_ONLY_KEY] === undefined ||
+    storage[TIER_SELECTOR_KEY] === undefined
   );
 };
 
@@ -219,18 +219,25 @@ export const isFirstRun = async (): Promise<boolean> => {
  * undefined인 경우, 기존 값은 유지하되 누락된 값만 기본값으로 초기화합니다.
  */
 export const initStorage = async () => {
-  if ((await browser.storage.sync.get(WEBHOOK_KEY)) === undefined)
+  const storage = await browser.storage.sync.get([
+    WEBHOOK_KEY,
+    SHOW_EMOJI_KEY,
+    SEND_FIRST_AC_ONLY_KEY,
+    TIER_SELECTOR_KEY,
+  ]);
+
+  if (storage[WEBHOOK_KEY] === undefined)
     await browser.storage.sync.set({ [WEBHOOK_KEY]: [] });
 
-  if ((await browser.storage.sync.get(SHOW_EMOJI_KEY)) === undefined)
+  if (storage[SHOW_EMOJI_KEY] === undefined)
     await browser.storage.sync.set({ [SHOW_EMOJI_KEY]: DEFAULT_SHOW_EMOJI });
 
-  if ((await browser.storage.sync.get(SEND_FIRST_AC_ONLY_KEY)) === undefined)
+  if (storage[SEND_FIRST_AC_ONLY_KEY] === undefined)
     await browser.storage.sync.set({
       [SEND_FIRST_AC_ONLY_KEY]: DEFAULT_SEND_FIRST_AC_ONLY,
     });
-    
-  if ((await browser.storage.sync.get(TIER_SELECTOR_KEY)) === undefined)
+
+  if (storage[TIER_SELECTOR_KEY] === undefined)
     await browser.storage.sync.set({
       [TIER_SELECTOR_KEY]: {
         start: DEFAULT_TIER_SELECTOR_START,

--- a/lib/browser.ts
+++ b/lib/browser.ts
@@ -4,9 +4,6 @@ import {
   SEND_FIRST_AC_ONLY_KEY,
   SHOW_EMOJI_KEY,
   WEBHOOK_KEY,
-
-  DEFAULT_TIER_SELECTOR_START,
-  DEFAULT_TIER_SELECTOR_END,
 } from "./constants";
 import { createUUID } from "./util";
 import { Webhook } from "./webhook";

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,7 +12,7 @@ export const TIER_SELECTOR_KEY = "tierSelector";
 export const DEFAULT_SHOW_EMOJI = true;
 export const DEFAULT_SEND_FIRST_AC_ONLY = false;
 export const DEFAULT_TIER_SELECTOR_START = 0;     // Unrated
-export const DEFAULT_TIER_SELECTOR_END = 31;      // Master
+export const DEFAULT_TIER_SELECTOR_END = 30;      // Ruby I
 
 export const HANDLE_QUERY = "a.username";
 export const AC_TITLE_TOOLTIP_QUERY = "a.problem_title.tooltip-click.result-ac";

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -10,8 +10,10 @@ export const SEND_FIRST_AC_ONLY_KEY = "webhookFirstAcceptOnly";
 
 export const DEFAULT_SHOW_EMOJI = true;
 export const DEFAULT_SEND_FIRST_AC_ONLY = false;
-export const DEFAULT_TIER_SELECTOR_START = 0;     // Unrated
-export const DEFAULT_TIER_SELECTOR_END = 30;      // Ruby I
+export const DEFAULT_TIER_SELECTION_START = 1; // Bronze V
+export const DEFAULT_TIER_SELECTION_END = 30; // Ruby I
+export const DEFAULT_TIER_SELECTOR_START = DEFAULT_TIER_SELECTION_START;
+export const DEFAULT_TIER_SELECTOR_END = DEFAULT_TIER_SELECTION_END;
 
 export const HANDLE_QUERY = "a.username";
 export const AC_TITLE_TOOLTIP_QUERY = "a.problem_title.tooltip-click.result-ac";

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,7 +7,6 @@ export const CHROME_STORE_URL =
 export const WEBHOOK_KEY = "webhooks";
 export const SHOW_EMOJI_KEY = "showEmoji";
 export const SEND_FIRST_AC_ONLY_KEY = "webhookFirstAcceptOnly";
-export const TIER_SELECTOR_KEY = "tierSelector";
 
 export const DEFAULT_SHOW_EMOJI = true;
 export const DEFAULT_SEND_FIRST_AC_ONLY = false;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,8 +7,12 @@ export const CHROME_STORE_URL =
 export const WEBHOOK_KEY = "webhooks";
 export const SHOW_EMOJI_KEY = "showEmoji";
 export const SEND_FIRST_AC_ONLY_KEY = "webhookFirstAcceptOnly";
+export const TIER_SELECTOR_KEY = "tierSelector";
+
 export const DEFAULT_SHOW_EMOJI = true;
 export const DEFAULT_SEND_FIRST_AC_ONLY = false;
+export const DEFAULT_TIER_SELECTOR_START = 0;     // Unrated
+export const DEFAULT_TIER_SELECTOR_END = 31;      // Master
 
 export const HANDLE_QUERY = "a.username";
 export const AC_TITLE_TOOLTIP_QUERY = "a.problem_title.tooltip-click.result-ac";

--- a/lib/shadcn-utils.ts
+++ b/lib/shadcn-utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/lib/tier.ts
+++ b/lib/tier.ts
@@ -1,0 +1,49 @@
+export const BASE_IMG =
+  "https://cdn.jsdelivr.net/gh/5tarlight/vlog-image@main/bjcord/solved-tier/";
+
+export const TIER_COLORS: Record<number, string> = {
+  0: "#9d9d9d",
+  1: "#ad5600", 2: "#ad5600", 3: "#ad5600", 4: "#ad5600", 5: "#ad5600",
+  6: "#435f7a", 7: "#435f7a", 8: "#435f7a", 9: "#435f7a", 10: "#435f7a",
+  11: "#ec9b00", 12: "#ec9b00", 13: "#ec9b00", 14: "#ec9b00", 15: "#ec9b00",
+  16: "#27e2a4", 17: "#27e2a4", 18: "#27e2a4", 19: "#27e2a4", 20: "#27e2a4",
+  21: "#00b4fc", 22: "#00b4fc", 23: "#00b4fc", 24: "#00b4fc", 25: "#00b4fc",
+  26: "#ff0062", 27: "#ff0062", 28: "#ff0062", 29: "#ff0062", 30: "#ff0062",
+};
+
+/** 각 티어 경계 마커 (슬라이더용) */
+export const TIER_MARKERS = [
+  { level: 0, img: "unrated", label: "Unrated" },
+  { level: 1, img: "bronze5", label: "Bronze V" },
+  { level: 6, img: "silver5", label: "Silver V" },
+  { level: 11, img: "gold5", label: "Gold V" },
+  { level: 16, img: "platinum5", label: "Plat V" },
+  { level: 21, img: "diamond5", label: "Diamond V" },
+  { level: 26, img: "ruby5", label: "Ruby V" },
+  { level: 30, img: "ruby1", label: "Ruby I" },
+] as const;
+
+export function getTierColor(tier: number): string {
+  return TIER_COLORS[tier] ?? "#9d9d9d";
+}
+
+/** 티어 레벨(0~30)에 대응하는 이미지 파일명 반환 */
+export function getTierImg(level: number): string {
+  if (level === 0) return "unrated";
+  const names = ["bronze", "silver", "gold", "platinum", "diamond", "ruby"];
+  const tierIdx = Math.ceil(level / 5) - 1;
+  const sub = 5 - ((level - 1) % 5);
+  return `${names[tierIdx]}${sub}`;
+}
+
+/**
+ * WebKit 기준 슬라이더 thumb 중심 CSS 위치 계산
+ * thumbDiameter=16px → offset = 8 - (level/30)*16
+ */
+export function thumbPos(level: number): string {
+  if (level === 30) return "95%";
+
+  const pct = (level / 30) * 100;
+  const offset = 8 - (level / 30) * 16;
+  return `calc(${pct.toFixed(3)}% + ${offset.toFixed(3)}px)`;
+}

--- a/lib/tier.ts
+++ b/lib/tier.ts
@@ -13,14 +13,13 @@ export const TIER_COLORS: Record<number, string> = {
 
 /** 각 티어 경계 마커 (슬라이더용) */
 export const TIER_MARKERS = [
-  { level: 0, img: "unrated", label: "Unrated" },
-  { level: 1, img: "bronze5", label: "Bronze V" },
-  { level: 6, img: "silver5", label: "Silver V" },
-  { level: 11, img: "gold5", label: "Gold V" },
-  { level: 16, img: "platinum5", label: "Plat V" },
-  { level: 21, img: "diamond5", label: "Diamond V" },
-  { level: 26, img: "ruby5", label: "Ruby V" },
-  { level: 30, img: "ruby1", label: "Ruby I" },
+  { level: 1, img: "bronze5", label: "B5" },
+  { level: 6, img: "silver5", label: "S5" },
+  { level: 11, img: "gold5", label: "G5" },
+  { level: 16, img: "platinum5", label: "P5" },
+  { level: 21, img: "diamond5", label: "D5" },
+  { level: 26, img: "ruby5", label: "R5" },
+  { level: 30, img: "ruby1", label: "R1" },
 ] as const;
 
 export function getTierColor(tier: number): string {
@@ -43,7 +42,7 @@ export function getTierImg(level: number): string {
 export function thumbPos(level: number): string {
   if (level === 30) return "95%";
 
-  const pct = (level / 30) * 100;
-  const offset = 8 - (level / 30) * 16;
+  const pct = ((level - 1) / 29) * 100;
+  const offset = 8 - ((level - 1) / 29) * 16;
   return `calc(${pct.toFixed(3)}% + ${offset.toFixed(3)}px)`;
 }

--- a/lib/webhook.ts
+++ b/lib/webhook.ts
@@ -7,6 +7,8 @@ export interface Webhook {
   url: string;
   displayName?: string;
   active: boolean;
+  tierMin?: number; // 0 = Unrated (기본)
+  tierMax?: number; // 31 = Master (기본)
 }
 
 /**
@@ -20,7 +22,9 @@ export interface Webhook {
 export const createWebhook = (
   name: string,
   url: string,
-  displayName?: string
+  displayName?: string,
+  tierMin?: number,
+  tierMax?: number
 ): Webhook => {
   return {
     id: createUUID(),
@@ -28,6 +32,8 @@ export const createWebhook = (
     url,
     displayName,
     active: true,
+    tierMin: tierMin ?? 0,
+    tierMax: tierMax ?? 31,
   };
 };
 

--- a/lib/webhook.ts
+++ b/lib/webhook.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_TIER_SELECTION_END,
+  DEFAULT_TIER_SELECTION_START,
+} from "./constants";
 import { getWebhooks, syncWebhooks } from "./browser";
 import { createUUID } from "./util";
 
@@ -7,8 +11,9 @@ export interface Webhook {
   url: string;
   displayName?: string;
   active: boolean;
-  tierMin?: number; // 0 = Unrated (기본)
-  tierMax?: number; // 31 = Master (기본)
+  tierMin?: number;
+  tierMax?: number;
+  includeUnrated?: boolean;
 }
 
 /**
@@ -24,7 +29,8 @@ export const createWebhook = (
   url: string,
   displayName?: string,
   tierMin?: number,
-  tierMax?: number
+  tierMax?: number,
+  includeUnrated = true
 ): Webhook => {
   return {
     id: createUUID(),
@@ -32,8 +38,9 @@ export const createWebhook = (
     url,
     displayName,
     active: true,
-    tierMin: tierMin ?? 0,
-    tierMax: tierMax ?? 30,
+    tierMin: tierMin ?? DEFAULT_TIER_SELECTION_START,
+    tierMax: tierMax ?? DEFAULT_TIER_SELECTION_END,
+    includeUnrated,
   };
 };
 

--- a/lib/webhook.ts
+++ b/lib/webhook.ts
@@ -33,7 +33,7 @@ export const createWebhook = (
     displayName,
     active: true,
     tierMin: tierMin ?? 0,
-    tierMax: tierMax ?? 31,
+    tierMax: tierMax ?? 30,
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -15,14 +15,21 @@
     "postinstall": "wxt prepare"
   },
   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
     "@tailwindcss/vite": "^4.1.13",
     "@yeahx4/cn": "^1.0.5",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.546.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-icons": "^5.5.0",
-    "tailwindcss": "^4.1.13"
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.13",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@types/node": "^24.9.1",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@wxt-dev/auto-icons": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tailwindcss/vite':
         specifier: ^4.1.13
-        version: 4.1.13(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 4.1.13(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))
       '@yeahx4/cn':
         specifier: ^1.0.5
         version: 1.0.5
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.546.0
+        version: 0.546.0(react@19.1.1)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -23,10 +35,19 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.1.1)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
       tailwindcss:
         specifier: ^4.1.13
         version: 4.1.13
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
+      '@types/node':
+        specifier: ^24.9.1
+        version: 24.9.1
       '@types/react':
         specifier: ^19.1.12
         version: 19.1.13
@@ -35,16 +56,16 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       '@wxt-dev/auto-icons':
         specifier: ^1.1.0
-        version: 1.1.0(wxt@0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))
+        version: 1.1.0(wxt@0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))
       '@wxt-dev/module-react':
         specifier: ^1.1.3
-        version: 1.1.5(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))(wxt@0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))
+        version: 1.1.5(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))(wxt@0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
       wxt:
         specifier: ^0.20.6
-        version: 0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
+        version: 0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
 
 packages:
 
@@ -320,6 +341,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -497,6 +533,258 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.35':
     resolution: {integrity: sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==}
@@ -723,8 +1011,8 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/node@24.5.1':
-    resolution: {integrity: sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==}
+  '@types/node@24.9.1':
+    resolution: {integrity: sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==}
 
   '@types/react-dom@19.1.9':
     resolution: {integrity: sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==}
@@ -805,6 +1093,10 @@ packages:
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   array-differ@4.0.0:
     resolution: {integrity: sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==}
@@ -922,6 +1214,9 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -957,6 +1252,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1076,6 +1375,9 @@ packages:
   detect-libc@2.1.0:
     resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1242,6 +1544,10 @@ packages:
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
@@ -1587,6 +1893,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.546.0:
+    resolution: {integrity: sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
@@ -1852,6 +2163,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.1:
+    resolution: {integrity: sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
@@ -2053,6 +2394,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
   tailwindcss@4.1.13:
     resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
 
@@ -2095,6 +2439,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
   type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
@@ -2117,8 +2464,8 @@ packages:
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
-  undici-types@7.12.0:
-    resolution: {integrity: sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unimport@5.2.0:
     resolution: {integrity: sha512-bTuAMMOOqIAyjV4i4UH7P07pO+EsVxmhOzQ2YJ290J6mkLUdozNhb5I/YoOEheeNADC03ent3Qj07X0fWfUpmw==}
@@ -2145,6 +2492,26 @@ packages:
   update-notifier@7.3.1:
     resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
     engines: {node: '>=18'}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2530,6 +2897,23 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.4':
@@ -2671,6 +3055,224 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      aria-hidden: 1.2.6
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-remove-scroll: 2.7.1(@types/react@19.1.13)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/rect@1.1.1': {}
+
   '@rolldown/pluginutils@1.0.0-beta.35': {}
 
   '@rollup/rollup-android-arm-eabi@4.50.2':
@@ -2800,12 +3402,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.13(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -2840,9 +3442,9 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
-  '@types/node@24.5.1':
+  '@types/node@24.9.1':
     dependencies:
-      undici-types: 7.12.0
+      undici-types: 7.16.0
 
   '@types/react-dom@19.1.9(@types/react@19.1.13)':
     dependencies:
@@ -2854,10 +3456,10 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.9.1
     optional: true
 
-  '@vitejs/plugin-react@5.0.3(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@5.0.3(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -2865,7 +3467,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.35
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2879,22 +3481,22 @@ snapshots:
 
   '@webext-core/match-patterns@1.0.3': {}
 
-  '@wxt-dev/auto-icons@1.1.0(wxt@0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))':
+  '@wxt-dev/auto-icons@1.1.0(wxt@0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))':
     dependencies:
       defu: 6.1.4
       fs-extra: 11.3.2
       sharp: 0.34.4
-      wxt: 0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
+      wxt: 0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
 
   '@wxt-dev/browser@0.1.4':
     dependencies:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.1.5(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))(wxt@0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))':
+  '@wxt-dev/module-react@1.1.5(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))(wxt@0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2))':
     dependencies:
-      '@vitejs/plugin-react': 5.0.3(vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1))
-      wxt: 0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
+      '@vitejs/plugin-react': 5.0.3(vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1))
+      wxt: 0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2)
     transitivePeerDependencies:
       - supports-color
       - vite
@@ -2930,6 +3532,10 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   array-differ@4.0.0: {}
 
@@ -3043,7 +3649,7 @@ snapshots:
 
   chrome-launcher@1.2.0:
     dependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.9.1
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -3055,6 +3661,10 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
 
   cli-boxes@3.0.0: {}
 
@@ -3095,6 +3705,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3189,6 +3801,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -3365,6 +3979,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-nonce@1.0.1: {}
 
   get-port-please@3.2.0: {}
 
@@ -3644,6 +4260,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.546.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
 
   magic-string@0.30.19:
     dependencies:
@@ -3956,6 +4576,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-style-singleton: 2.2.3(@types/react@19.1.13)(react@19.1.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  react-remove-scroll@2.7.1(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.13)(react@19.1.1)
+      react-style-singleton: 2.2.3(@types/react@19.1.13)(react@19.1.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.13)(react@19.1.1)
+      use-sidecar: 1.1.3(@types/react@19.1.13)(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  react-style-singleton@2.2.3(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
   react@19.1.1: {}
 
   readable-stream@2.3.8:
@@ -4183,6 +4830,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tailwind-merge@3.3.1: {}
+
   tailwindcss@4.1.13: {}
 
   tapable@2.2.3: {}
@@ -4225,6 +4874,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tw-animate-css@1.4.0: {}
+
   type-fest@3.13.1: {}
 
   type-fest@4.41.0: {}
@@ -4237,7 +4888,7 @@ snapshots:
 
   uhyphen@0.2.0: {}
 
-  undici-types@7.12.0: {}
+  undici-types@7.16.0: {}
 
   unimport@5.2.0:
     dependencies:
@@ -4289,17 +4940,32 @@ snapshots:
       semver: 7.7.2
       xdg-basedir: 5.1.0
 
+  use-callback-ref@1.3.3(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
+  use-sidecar@1.1.3(@types/react@19.1.13)(react@19.1.1):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.1.1
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.13
+
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
 
-  vite-node@3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1):
+  vite-node@3.2.4(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4314,7 +4980,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1):
+  vite@7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4323,7 +4989,7 @@ snapshots:
       rollup: 4.50.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 24.5.1
+      '@types/node': 24.9.1
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1
@@ -4401,7 +5067,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
 
-  wxt@0.20.11(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2):
+  wxt@0.20.11(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.2):
     dependencies:
       '@1natsu/wait-element': 4.1.2
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.50.2)
@@ -4445,8 +5111,8 @@ snapshots:
       publish-browser-extension: 3.0.2
       scule: 1.3.0
       unimport: 5.2.0
-      vite: 7.1.5(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)
-      vite-node: 3.2.4(@types/node@24.5.1)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite-node: 3.2.4(@types/node@24.9.1)(jiti@2.5.1)(lightningcss@1.30.1)
       web-ext-run: 0.2.4
     transitivePeerDependencies:
       - '@types/node'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
     "allowImportingTsExtensions": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "wxt";
 
@@ -26,5 +27,10 @@ export default defineConfig({
   }),
   vite: () => ({
     plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
   }),
 });


### PR DESCRIPTION
## 관련 이슈
- resolve #61 

## PR 설명

각 웹훅별로 전송할 문제의 난이도 범위를 설정할 수 있는 기능을 추가했습니다.

기존에는 모든 난이도의 문제가 동일하게 전송되었지만,
이제는 웹훅마다 원하는 티어 범위를 지정하여 필터링된 문제만 받아볼 수 있습니다.

- 난이도 범위는 `Unrated (0)`부터 `Ruby I (30)`까지 설정 가능합니다.
- 양방향 슬라이더와 드롭다운을 함께 제공하여 직관적으로 범위를 조절할 수 있도록 구성했습니다.
- UI는 솔브닥의 문제 선택 인터페이스를 참고하여 설계했습니다.
  <img width="313" height="133" alt="Image" src="https://github.com/user-attachments/assets/32ef3ced-7be1-486c-a67c-6f151c1c304f" />
  

## 스크린샷

- **여러 웹훅이 있는 설정 페이지 UI**
<img width="978" height="744" alt="image" src="https://github.com/user-attachments/assets/9b53315e-d18f-4c5d-8d2a-8e38874203bf" />

- **티어 선택 툴팁(모달) UI**
<img width="577" height="380" alt="image" src="https://github.com/user-attachments/assets/c763ff92-3d81-4fdd-a0fd-bbca92fe0b30" />

## 주요 변경사항

- 웹훅 설정에 난이도 범위 필터 기능 추가
- `sync` 스토리지 웹훅 객체에 `minTier`, `maxTier` 필드 추가
- 티어 선택을 위한 슬라이더 + 드롭다운이 조합된 UI 구현

## 리뷰 요청사항
- `sync` 스토리지에 `minTier`, `maxTier` 필드가 추가되면서
  기존 데이터와의 호환성 문제(기본값 처리 등)가 없는지 확인 부탁드립니다.

- 설정한 난이도 범위에 따라
  의도한 티어의 문제만 정상적으로 전송되는지 동작 검증 부탁드립니다.
